### PR TITLE
Remove prefix from issue title.

### DIFF
--- a/.github/ISSUE_TEMPLATE/task.md
+++ b/.github/ISSUE_TEMPLATE/task.md
@@ -1,7 +1,7 @@
 ---
 name: Task
 about: Represents a concrete implementation task that needs completing
-title: "[TASK] "
+title: ''
 labels: ''
 assignees: ''
 


### PR DESCRIPTION
It looks noisy on kanban dashboard.
How about using labels instead, to identify type of issue?