### PR TITLE
Make scaffold looking closer to travel-app mocks.

### DIFF
--- a/examples/travel_app/lib/main.dart
+++ b/examples/travel_app/lib/main.dart
@@ -71,6 +71,7 @@ class MyApp extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return MaterialApp(
+      debugShowCheckedModeBanner: false,
       title: 'Dynamic UI Demo',
       theme: ThemeData(
         colorScheme: ColorScheme.fromSeed(seedColor: Colors.blue),
@@ -121,8 +122,15 @@ class _MyHomePageState extends State<MyHomePage> {
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(
-        backgroundColor: Theme.of(context).colorScheme.inversePrimary,
-        title: const Text('Dynamic UI Demo'),
+        leading: const Icon(Icons.menu),
+        title: const Row(
+          children: <Widget>[
+            Icon(Icons.chat_bubble_outline),
+            SizedBox(width: 8.0), // Add spacing between icon and text
+            Text('Dynamic UI Demo'),
+          ],
+        ),
+        actions: [const Icon(Icons.person_outline), const SizedBox(width: 8.0)],
       ),
       body: Center(
         child: ConstrainedBox(


### PR DESCRIPTION
Fixes https://github.com/flutter/genui/issues/47

Before:
<img width="445" height="645" alt="Screenshot 2025-08-04 at 6 41 12 PM" src="https://github.com/user-attachments/assets/0d0962d1-5239-4770-a621-b62efb743dce" />


After:
<img width="488" height="706" alt="Screenshot 2025-08-04 at 6 44 58 PM" src="https://github.com/user-attachments/assets/ab197ebf-62a3-4b6d-ad44-7693049f0763" />


