### PR TITLE
Add loading scrim.

### DIFF
--- a/examples/travel_app/lib/main.dart
+++ b/examples/travel_app/lib/main.dart
@@ -40,13 +40,15 @@ class MyApp extends StatelessWidget {
 }
 
 class MyHomePage extends StatefulWidget {
-  const MyHomePage({super.key});
+  const MyHomePage({super.key, this.aiClient});
+
+  final AiClient? aiClient;
 
   @override
-  State<MyHomePage> createState() => _MyHomePageState();
+  State<MyHomePage> createState() => MyHomePageState();
 }
 
-class _MyHomePageState extends State<MyHomePage> {
+class MyHomePageState extends State<MyHomePage> {
   final _promptController = TextEditingController();
   late final GenUiManager _genUiManager;
   late AiClient aiClient;
@@ -138,43 +140,40 @@ class _MyHomePageState extends State<MyHomePage> {
       body: Center(
         child: ConstrainedBox(
           constraints: const BoxConstraints(maxWidth: 1000),
-          child: Column(
-            children: [
-              Expanded(child: _genUiManager.widget()),
-              Padding(
-                padding: const EdgeInsets.all(8.0),
-                child: Row(
+          child: StreamBuilder<bool>(
+            stream: _genUiManager.loadingStream,
+            initialData: false,
+            builder: (context, snapshot) {
+              final isLoading = snapshot.data ?? false;
+              return LoadingScrim(
+                isLoading: isLoading,
+                child: Column(
                   children: [
-                    Expanded(
-                      child: TextField(
-                        controller: _promptController,
-                        decoration: const InputDecoration(
-                          hintText: 'Enter a UI prompt',
-                        ),
-                        onSubmitted: (_) => _sendPrompt(),
+                    Expanded(child: _genUiManager.widget()),
+                    Padding(
+                      padding: const EdgeInsets.all(8.0),
+                      child: Row(
+                        children: [
+                          Expanded(
+                            child: TextField(
+                              controller: _promptController,
+                              decoration: const InputDecoration(
+                                hintText: 'Enter a UI prompt',
+                              ),
+                              onSubmitted: (_) => _sendPrompt(),
+                            ),
+                          ),
+                          IconButton(
+                            icon: const Icon(Icons.send),
+                            onPressed: _sendPrompt,
+                          ),
+                        ],
                       ),
-                    ),
-                    IconButton(
-                      icon: const Icon(Icons.send),
-                      onPressed: _sendPrompt,
-                    ),
-                    StreamBuilder<bool>(
-                      stream: _genUiManager.loadingStream,
-                      initialData: false,
-                      builder: (context, snapshot) {
-                        if (snapshot.data ?? false) {
-                          return const Padding(
-                            padding: EdgeInsets.all(8.0),
-                            child: CircularProgressIndicator(),
-                          );
-                        }
-                        return const SizedBox.shrink();
-                      },
                     ),
                   ],
                 ),
-              ),
-            ],
+              );
+            },
           ),
         ),
       ),

--- a/examples/travel_app/test/loading_scrim_test.dart
+++ b/examples/travel_app/test/loading_scrim_test.dart
@@ -1,0 +1,104 @@
+// Copyright 2025 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:async';
+
+import 'package:firebase_ai/firebase_ai.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_genui/flutter_genui.dart';
+import 'package:flutter_genui/src/ai_client/generative_model_interface.dart';
+import 'package:flutter_genui/src/ai_client/tools.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:travel_app/main.dart';
+
+class MockLlmConnection implements LlmConnection {
+  final Completer<Map<String, Object?>> _completer = Completer();
+  final StreamController<bool> _loadingStreamController =
+      StreamController<bool>.broadcast();
+
+  @override
+  Future<T?> generateContent<T extends Object>(
+    List<Content> conversation,
+    Schema outputSchema, {
+    Iterable<AiTool> additionalTools = const [],
+    Content? systemInstruction,
+  }) async {
+    _loadingStreamController.add(true);
+    final result = await _completer.future;
+    _loadingStreamController.add(false);
+    return result as T?;
+  }
+
+  void complete() {
+    _completer.complete({'responseText': 'Test response'});
+  }
+}
+
+void main() {
+  testWidgets('Loading scrim shows during inference', (
+    WidgetTester tester,
+  ) async {
+    final mockLlmConnection = MockLlmConnection();
+    final aiClient = AiClient.test(
+      modelCreator:
+          ({
+            required AiClient configuration,
+            Content? systemInstruction,
+            List<Tool>? tools,
+            ToolConfig? toolConfig,
+          }) {
+            return MockGenerativeModel(mockLlmConnection);
+          },
+    );
+
+    await tester.pumpWidget(MaterialApp(home: MyHomePage(aiClient: aiClient)));
+
+    // Verify the loading scrim is not visible initially
+    expect(find.byType(LoadingScrim), findsOneWidget);
+    final loadingScrim = tester.widget<LoadingScrim>(find.byType(LoadingScrim));
+    expect(loadingScrim.isLoading, isFalse);
+
+    // Enter a prompt and send it
+    await tester.enterText(find.byType(TextField), 'test prompt');
+    await tester.tap(find.byIcon(Icons.send));
+    await tester.pump();
+
+    // Verify the loading scrim is now visible
+    final loadingScrimInProgress = tester.widget<LoadingScrim>(
+      find.byType(LoadingScrim),
+    );
+    expect(loadingScrimInProgress.isLoading, isTrue);
+    expect(find.byType(CircularProgressIndicator), findsOneWidget);
+
+    // Complete the inference
+    mockLlmConnection.complete();
+    await tester.pump();
+
+    // Verify the loading scrim is hidden again
+    final loadingScrimFinished = tester.widget<LoadingScrim>(
+      find.byType(LoadingScrim),
+    );
+    expect(loadingScrimFinished.isLoading, isFalse);
+    expect(find.byType(CircularProgressIndicator), findsNothing);
+  });
+}
+
+class MockGenerativeModel implements GenerativeModelInterface {
+  final MockLlmConnection _llmConnection;
+
+  MockGenerativeModel(this._llmConnection);
+
+  @override
+  Future<GenerateContentResponse> generateContent(
+    Iterable<Content> content,
+  ) async {
+    final result = await _llmConnection.generateContent(
+      content.toList(),
+      Schema.object(properties: {}),
+    );
+    return GenerateContentResponse([
+      Candidate(Content.text(result.toString()), null, null, null, null),
+    ], null);
+  }
+}

--- a/pkgs/flutter_genui/lib/flutter_genui.dart
+++ b/pkgs/flutter_genui/lib/flutter_genui.dart
@@ -18,3 +18,4 @@ export 'src/model/catalog.dart';
 export 'src/model/catalog_item.dart';
 export 'src/model/surface_widget.dart';
 export 'src/model/ui_models.dart';
+export 'src/widgets/loading_scrim.dart';

--- a/pkgs/flutter_genui/lib/src/ai_client/ai_client.dart
+++ b/pkgs/flutter_genui/lib/src/ai_client/ai_client.dart
@@ -80,8 +80,8 @@ class AiClient implements LlmConnection {
     this.tools = const <AiTool>[],
     this.outputToolName = 'provideFinalOutput',
     String? systemInstruction,
-  })  : _systemInstruction = systemInstruction,
-        model = ValueNotifier(model) {
+  }) : _systemInstruction = systemInstruction,
+       model = ValueNotifier(model) {
     final duplicateToolNames = tools.map((t) => t.name).toSet();
     if (duplicateToolNames.length != tools.length) {
       final duplicateTools = tools.where((t) {
@@ -108,8 +108,8 @@ class AiClient implements LlmConnection {
     this.tools = const <AiTool>[],
     this.outputToolName = 'provideFinalOutput',
     String? systemInstruction,
-  })  : _systemInstruction = systemInstruction,
-        model = ValueNotifier(model) {
+  }) : _systemInstruction = systemInstruction,
+       model = ValueNotifier(model) {
     final duplicateToolNames = tools.map((t) => t.name).toSet();
     if (duplicateToolNames.length != tools.length) {
       final duplicateTools = tools.where((t) {
@@ -431,8 +431,9 @@ class AiClient implements LlmConnection {
 
     final model = modelCreator(
       configuration: this,
-      systemInstruction:
-          _systemInstruction == null ? null : Content.system(_systemInstruction!),
+      systemInstruction: _systemInstruction == null
+          ? null
+          : Content.system(_systemInstruction!),
       tools: generativeAiTools,
       toolConfig: ToolConfig(
         functionCallingConfig: FunctionCallingConfig.any(

--- a/pkgs/flutter_genui/lib/src/widgets/loading_scrim.dart
+++ b/pkgs/flutter_genui/lib/src/widgets/loading_scrim.dart
@@ -1,0 +1,28 @@
+// Copyright 2025 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter/material.dart';
+
+class LoadingScrim extends StatelessWidget {
+  final bool isLoading;
+  final Widget child;
+
+  const LoadingScrim({super.key, required this.isLoading, required this.child});
+
+  @override
+  Widget build(BuildContext context) {
+    return Stack(
+      children: [
+        child,
+        if (isLoading)
+          Positioned.fill(
+            child: Container(
+              color: Colors.black.withValues(alpha: 0.12),
+              child: const Center(child: CircularProgressIndicator()),
+            ),
+          ),
+      ],
+    );
+  }
+}

--- a/pkgs/spikes/usage_test/lib/main.dart
+++ b/pkgs/spikes/usage_test/lib/main.dart
@@ -35,8 +35,9 @@ class MyHomePage extends StatefulWidget {
 }
 
 class _MyHomePageState extends State<MyHomePage> {
-  final GenUiManager _genUiManager =
-      GenUiManager.conversation(llmConnection: AiClient());
+  final GenUiManager _genUiManager = GenUiManager.conversation(
+    llmConnection: AiClient(),
+  );
 
   @override
   void initState() {


### PR DESCRIPTION
Adds a `LoadingScrim` widget to the `flutter_genui` package to
provide a visual indicator and disable UI interaction while an LLM
inference is in flight.

The `travel_app` example has been updated to use this new widget,
wrapping the main UI surface and the prompt input field. The
`loadingStream` from the `GenUiManager` is used to control the
visibility of the scrim.

A new widget test has been added to verify that the scrim is
displayed correctly when an inference is in progress.
