### PR TITLE
Add validation for cycles.

### DIFF
--- a/.github/workflows/flutter_packages.yaml
+++ b/.github/workflows/flutter_packages.yaml
@@ -110,6 +110,8 @@ jobs:
         with:
           channel: ${{ matrix.flutter_version }}
           cache: true
+      - name: Print Flutter version
+        run: flutter --version
       - name: Cache Pub dependencies
         uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684
         with:
@@ -136,3 +138,5 @@ jobs:
           else
             echo "No 'test' directory found in ${{ matrix.package.path }}, skipping tests."
           fi
+      - name: Check for cycles
+        run: dart pub global activate layerlens && layerlens --fail-on-cycles


### PR DESCRIPTION
Employ [layerlens](https://pub.dev/packages/layerlens) to watch dep cycles, similar to how [DartPad is doing it](https://github.com/dart-lang/dart-pad/blob/15a0e2c64f38fe84892cb11dd999af0f90e488cd/.github/workflows/dartpad_shared.yml#L40). 