### PR TITLE
Respect safe area in travel app

### DIFF
--- a/examples/travel_app/lib/main.dart
+++ b/examples/travel_app/lib/main.dart
@@ -156,12 +156,14 @@ class _TravelPlannerPageState extends State<TravelPlannerPage> {
           const SizedBox(width: 8.0),
         ],
       ),
-      body: Center(
-        child: ConstrainedBox(
-          constraints: const BoxConstraints(maxWidth: 1000),
-          child: Padding(
-            padding: const EdgeInsets.all(8.0),
-            child: _genUiManager.widget(),
+      body: SafeArea(
+        child: Center(
+          child: ConstrainedBox(
+            constraints: const BoxConstraints(maxWidth: 1000),
+            child: Padding(
+              padding: const EdgeInsets.all(8.0),
+              child: _genUiManager.widget(),
+            ),
           ),
         ),
       ),


### PR DESCRIPTION
This is a minor fix to ensure the chat area respects the safe area on iOS e.g. doesn't overlap with the navigation bar at the bottom of the screen.

Just a small thing, but it looks awkward in mobile demos.

Before:

<img width="603" height="1311" alt="Simulator Screenshot - iPhone 16 Pro - 2025-08-19 at 12 22 53" src="https://github.com/user-attachments/assets/400ebd08-e476-4e8b-863d-2d51d5b839e6" />

After:

<img width="603" height="1311" alt="Simulator Screenshot - iPhone 16 Pro - 2025-08-19 at 12 21 35" src="https://github.com/user-attachments/assets/4f52a6f0-a4bc-472f-901b-0cfa858c6589" />

