### PR TITLE
Remove copyright header from generated files

### DIFF
--- a/examples/travel_app/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/examples/travel_app/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -1,7 +1,3 @@
-// Copyright 2025 The Flutter Authors. All rights reserved.
-// Use of this source code is governed by a BSD-style license that can be
-// found in the LICENSE file.
-
 //
 //  Generated file. Do not edit.
 //

--- a/examples/travel_app/windows/flutter/generated_plugin_registrant.cc
+++ b/examples/travel_app/windows/flutter/generated_plugin_registrant.cc
@@ -1,7 +1,3 @@
-// Copyright 2025 The Flutter Authors. All rights reserved.
-// Use of this source code is governed by a BSD-style license that can be
-// found in the LICENSE file.
-
 //
 //  Generated file. Do not edit.
 //

--- a/examples/travel_app/windows/flutter/generated_plugin_registrant.h
+++ b/examples/travel_app/windows/flutter/generated_plugin_registrant.h
@@ -1,7 +1,3 @@
-// Copyright 2025 The Flutter Authors. All rights reserved.
-// Use of this source code is governed by a BSD-style license that can be
-// found in the LICENSE file.
-
 //
 //  Generated file. Do not edit.
 //


### PR DESCRIPTION
Without this change, I see the following in my git repo, because when Flutter regenerates these files from time to time, the copyright header gets removed:

```
Changes not staged for commit:
  (use "git add <file>..." to update what will be committed)
  (use "git restore <file>..." to discard changes in working directory)
	modified:   examples/travel_app/macos/Flutter/GeneratedPluginRegistrant.swift
	modified:   examples/travel_app/windows/flutter/generated_plugin_registrant.cc
	modified:   examples/travel_app/windows/flutter/generated_plugin_registrant.h
```

I think we can remove the header from the generated file for practical purposes. We already don't have a copyright header on generated files such as pubspec.lock.