### PR TITLE
Fix setState calls so they wrap state updates following Flutter conventions

### DIFF
--- a/examples/simple_chat/lib/main.dart
+++ b/examples/simple_chat/lib/main.dart
@@ -54,6 +54,7 @@ class _ChatScreenState extends State<ChatScreen> {
   final ScrollController _scrollController = ScrollController();
 
   void _onSurfaceAdded(SurfaceAdded surface) {
+    if (!mounted) return;
     setState(() {
       _messages.add(MessageController(surfaceId: surface.surfaceId));
     });


### PR DESCRIPTION
Note that the removed setState call is unnecessary, because this event is already handled in _onSurfaceAdded.