### PR TITLE
Test script: 4x speed increase and improved LLM-friendly output

### DIFF
--- a/tool/run_all_tests_and_fixes.sh
+++ b/tool/run_all_tests_and_fixes.sh
@@ -47,10 +47,7 @@ run_project_step() {
     echo "### [$step_num/$PROJECT_TOTAL_STEPS] $description"
     echo "> To rerun this command:"
     echo "> 
-> 
 > (cd \"$project_dir\" && $cmd_str_for_display)
-> 
-> 
 > "
     if ! "${cmd_to_run[@]}"; then
         echo "'(cd \"$project_dir\" && $cmd_str_to_run)' failed" >> "$FAILURE_LOG"
@@ -91,10 +88,7 @@ if [ -f "tool/fix_copyright/bin/fix_copyright.dart" ]; then
     echo "### Running copyright fix"
     echo "> To rerun this command:"
     echo "> 
-> 
 > dart run tool/fix_copyright/bin/fix_copyright.dart --force
-> 
-> 
 > "
     # Log failures without stopping the script.
     dart run tool/fix_copyright/bin/fix_copyright.dart --force >/dev/null 2>&1 || true
@@ -109,8 +103,7 @@ echo ""
 # --- 1. Find all Flutter projects ---
 # We find all `pubspec.yaml` files and process each one.
 # The `find ... -print0 | while ...` construct safely handles file paths with spaces.
-echo "## Searching for Flutter projects"
-echo "=================================================="
+echo "Searching for Flutter projects..."
 
 # Collect all project directories first to process them in a stable order.
 project_dirs=()


### PR DESCRIPTION
This pull request introduces several improvements to the `run_all_tests_and_fixes.sh` script, focusing on parallelization, output formatting, and user experience.

It now runs in 11 seconds for me, vs ~40 seconds before, and the output isn't cluttered with logs which sometimes confused Gemini. Together, this can speed up the Gemini CLI feedback loop quite a bit :-D.

### Key Changes:

- **Parallel Execution**: The script now runs tests and analysis for all projects in parallel, significantly reducing the overall execution time.
- **Improved Output Formatting**: The output has been updated to use markdown, making it more structured and easier for both humans and LLMs to parse.
- **Concise Test Logs**: The `flutter test` command now uses the `--reporter=failures-only` option to provide a more concise summary of test results.
- **User-Friendly Rerun Commands**: The commands for rerunning tests are now formatted as one-liners that can be executed from any directory.
- **Exclusion of Spike Packages**: The script now properly excludes packages located in the `packages/spikes` directory.
- **Error Suppression**: All output from the `fix_copyright` script is now suppressed to reduce noise.