### PR TITLE
Add .firebaserc to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,3 +62,4 @@ app.*.map.json
 **/firebase.json
 **/GoogleService-Info.plist
 **/.firebase
+**/.firebaserc


### PR DESCRIPTION
The `.firebaserc` is required to set up Flutter Web deployment of the travel app. I added instructions on how to do that in our internal `flutter-genui-internal` Google Doc. This change just makes sure we don't accidentally check in the config file, which is for an internal GCP project.