### PR TITLE
 fix(email): use safe regex pattern for email validation

### DIFF
--- a/packages/dart_schema_builder/lib/src/formats.dart
+++ b/packages/dart_schema_builder/lib/src/formats.dart
@@ -6,6 +6,8 @@ import 'package:intl/intl.dart';
 
 typedef FormatValidator = bool Function(String);
 
+final _emailRegex = RegExp(r'^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$');
+
 final Map<String, FormatValidator> formatValidators = {
   'date-time': (value) {
     try {
@@ -31,11 +33,7 @@ final Map<String, FormatValidator> formatValidators = {
       return false;
     }
   },
-  'email': (value) {
-    return RegExp(
-      r"^[a-zA-Z0-9.a-zA-Z0-9.!#$%&'*+-/=?^_`{|}~-]+@[a-zA-Z0-9]+\.[a-zA-Z]+",
-    ).hasMatch(value);
-  },
+  'email': (value) => _emailRegex.hasMatch(value),
   'ipv4': (value) {
     final parts = value.split('.');
     if (parts.length != 4) return false;

--- a/packages/dart_schema_builder/test/formats_test.dart
+++ b/packages/dart_schema_builder/test/formats_test.dart
@@ -1,0 +1,28 @@
+import 'package:test/test.dart';
+import 'package:dart_schema_builder/dart_schema_builder.dart';
+import '../lib/src/formats.dart';
+
+void main() {
+  group('FormatValidator', () {
+    test('email validator should accept valid emails', () {
+      final validator = formatValidators['email']!;
+      expect(validator('test@example.com'), isTrue);
+      expect(validator('user.name+tag@example.co.uk'), isTrue);
+      expect(validator('123@abc.org'), isTrue);
+      expect(validator('a@b.io'), isTrue); // minimal valid
+    });
+
+    test('email validator should reject invalid emails', () {
+      final validator = formatValidators['email']!;
+      expect(validator(''), isFalse);
+      expect(validator('@example.com'), isFalse);
+      expect(validator('test@'), isFalse);
+      expect(validator('test@example'), isFalse);
+      expect(validator('test@.com'), isFalse);
+      expect(validator('test@com.'), isFalse);
+      expect(validator('test@@example.com'), isFalse);
+      expect(validator('test@ex ample.com'), isFalse); // space not allowed
+      expect(validator('test@x'), isFalse); // TLD too short
+    });
+  });
+}


### PR DESCRIPTION
Replaced broken email regex in dart_schema_builder with a correct, practical pattern:

    r'^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$'

Also fixed test failure by importing formatValidators via relative path.

All tests pass locally.