### PR TITLE
Add CMake files to the fix_copyright script.

### DIFF
--- a/examples/simple_chat/windows/flutter/generated_plugins.cmake
+++ b/examples/simple_chat/windows/flutter/generated_plugins.cmake
@@ -1,3 +1,7 @@
+# Copyright 2025 The Flutter Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
 #
 # Generated file, do not edit.
 #

--- a/tool/fix_copyright/lib/src/fix_copyright.dart
+++ b/tool/fix_copyright/lib/src/fix_copyright.dart
@@ -232,6 +232,7 @@ ${isParagraph ? '' : prefix}found in the LICENSE file.$suffix''';
 
   return <String, CopyrightInfo>{
     'dart': generateInfo(prefix: '// '),
+    'cmake': generateInfo(prefix: '# '),
     'java': generateInfo(prefix: '// '),
     'h': generateInfo(prefix: '// '),
     'm': generateInfo(prefix: '// '),


### PR DESCRIPTION
# Description

Adds a missing copyright header and fixes copyright script to enforce it.