### PR TITLE
Remove All Rights Reserved from copyright notices

### DIFF
--- a/.gemini/config.yaml
+++ b/.gemini/config.yaml
@@ -1,4 +1,4 @@
-# Copyright 2025 The Flutter Authors. All rights reserved.
+# Copyright 2025 The Flutter Authors.
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 

--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,4 +1,4 @@
-# Copyright 2025 The Flutter Authors. All rights reserved.
+# Copyright 2025 The Flutter Authors.
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 

--- a/.github/workflows/flutter_packages.yaml
+++ b/.github/workflows/flutter_packages.yaml
@@ -1,4 +1,4 @@
-# Copyright 2025 The Flutter Authors. All rights reserved.
+# Copyright 2025 The Flutter Authors.
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 

--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright 2025 The Flutter Authors. All rights reserved.
+Copyright 2025 The Flutter Authors.
 
 Redistribution and use in source and binary forms, with or without modification,
 are permitted provided that the following conditions are met:

--- a/examples/catalog_gallery/analysis_options.yaml
+++ b/examples/catalog_gallery/analysis_options.yaml
@@ -1,8 +1,7 @@
-# Copyright 2025 The Flutter Authors. All rights reserved.
+# Copyright 2025 The Flutter Authors.
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 
 include: package:dart_flutter_team_lints/analysis_options.yaml
-
 # Additional information about this file can be found at
 # https://dart.dev/guides/language/analysis-options

--- a/examples/catalog_gallery/ios/Runner/AppDelegate.swift
+++ b/examples/catalog_gallery/ios/Runner/AppDelegate.swift
@@ -1,4 +1,4 @@
-// Copyright 2025 The Flutter Authors. All rights reserved.
+// Copyright 2025 The Flutter Authors.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/examples/catalog_gallery/ios/RunnerTests/RunnerTests.swift
+++ b/examples/catalog_gallery/ios/RunnerTests/RunnerTests.swift
@@ -1,4 +1,4 @@
-// Copyright 2025 The Flutter Authors. All rights reserved.
+// Copyright 2025 The Flutter Authors.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/examples/catalog_gallery/lib/main.dart
+++ b/examples/catalog_gallery/lib/main.dart
@@ -1,4 +1,4 @@
-// Copyright 2025 The Flutter Authors. All rights reserved.
+// Copyright 2025 The Flutter Authors.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/examples/catalog_gallery/macos/Runner/AppDelegate.swift
+++ b/examples/catalog_gallery/macos/Runner/AppDelegate.swift
@@ -1,4 +1,4 @@
-// Copyright 2025 The Flutter Authors. All rights reserved.
+// Copyright 2025 The Flutter Authors.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/examples/catalog_gallery/macos/Runner/Configs/AppInfo.xcconfig
+++ b/examples/catalog_gallery/macos/Runner/Configs/AppInfo.xcconfig
@@ -11,4 +11,4 @@ PRODUCT_NAME = catalog_gallery
 PRODUCT_BUNDLE_IDENTIFIER = com.example.catalogGallery
 
 // The copyright displayed in application information
-PRODUCT_COPYRIGHT = Copyright © 2025 com.example. All rights reserved.
+PRODUCT_COPYRIGHT = Copyright © 2025 com.example.

--- a/examples/catalog_gallery/macos/Runner/MainFlutterWindow.swift
+++ b/examples/catalog_gallery/macos/Runner/MainFlutterWindow.swift
@@ -1,4 +1,4 @@
-// Copyright 2025 The Flutter Authors. All rights reserved.
+// Copyright 2025 The Flutter Authors.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/examples/catalog_gallery/macos/RunnerTests/RunnerTests.swift
+++ b/examples/catalog_gallery/macos/RunnerTests/RunnerTests.swift
@@ -1,4 +1,4 @@
-// Copyright 2025 The Flutter Authors. All rights reserved.
+// Copyright 2025 The Flutter Authors.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/examples/catalog_gallery/pubspec.yaml
+++ b/examples/catalog_gallery/pubspec.yaml
@@ -1,9 +1,9 @@
-# Copyright 2025 The Flutter Authors. All rights reserved.
+# Copyright 2025 The Flutter Authors.
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 
 name: catalog_gallery
-publish_to: 'none'
+publish_to: "none"
 version: 1.0.0+1
 
 environment:
@@ -19,7 +19,6 @@ dev_dependencies:
   dart_flutter_team_lints: ^3.5.2
   flutter_test:
     sdk: flutter
-
 
 flutter:
   uses-material-design: true

--- a/examples/catalog_gallery/test/widget_test.dart
+++ b/examples/catalog_gallery/test/widget_test.dart
@@ -1,4 +1,4 @@
-// Copyright 2025 The Flutter Authors. All rights reserved.
+// Copyright 2025 The Flutter Authors.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/examples/catalog_gallery/web/index.html
+++ b/examples/catalog_gallery/web/index.html
@@ -1,10 +1,10 @@
 <!DOCTYPE html>
-<!-- Copyright 2025 The Flutter Authors. All rights reserved.
+<!-- Copyright 2025 The Flutter Authors.
 Use of this source code is governed by a BSD-style license that can be
 found in the LICENSE file. -->
 <html>
-<head>
-  <!--
+  <head>
+    <!--
     If you are serving your web app in a path other than the root, change the
     href value below to reflect the base path you are serving from.
 
@@ -17,25 +17,25 @@ found in the LICENSE file. -->
     This is a placeholder for base href that will be replaced by the value of
     the `--base-href` argument provided to `flutter build`.
   -->
-  <base href="$FLUTTER_BASE_HREF">
+    <base href="$FLUTTER_BASE_HREF" />
 
-  <meta charset="UTF-8">
-  <meta content="IE=Edge" http-equiv="X-UA-Compatible">
-  <meta name="description" content="A new Flutter project.">
+    <meta charset="UTF-8" />
+    <meta content="IE=Edge" http-equiv="X-UA-Compatible" />
+    <meta name="description" content="A new Flutter project." />
 
-  <!-- iOS meta tags & icons -->
-  <meta name="mobile-web-app-capable" content="yes">
-  <meta name="apple-mobile-web-app-status-bar-style" content="black">
-  <meta name="apple-mobile-web-app-title" content="catalog_gallery">
-  <link rel="apple-touch-icon" href="icons/Icon-192.png">
+    <!-- iOS meta tags & icons -->
+    <meta name="mobile-web-app-capable" content="yes" />
+    <meta name="apple-mobile-web-app-status-bar-style" content="black" />
+    <meta name="apple-mobile-web-app-title" content="catalog_gallery" />
+    <link rel="apple-touch-icon" href="icons/Icon-192.png" />
 
-  <!-- Favicon -->
-  <link rel="icon" type="image/png" href="favicon.png"/>
+    <!-- Favicon -->
+    <link rel="icon" type="image/png" href="favicon.png" />
 
-  <title>catalog_gallery</title>
-  <link rel="manifest" href="manifest.json">
-</head>
-<body>
-  <script src="flutter_bootstrap.js" async></script>
-</body>
+    <title>catalog_gallery</title>
+    <link rel="manifest" href="manifest.json" />
+  </head>
+  <body>
+    <script src="flutter_bootstrap.js" async></script>
+  </body>
 </html>

--- a/examples/simple_chat/analysis_options.yaml
+++ b/examples/simple_chat/analysis_options.yaml
@@ -1,4 +1,4 @@
-# Copyright 2025 The Flutter Authors. All rights reserved.
+# Copyright 2025 The Flutter Authors.
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 
@@ -27,6 +27,5 @@ linter:
   rules:
     # avoid_print: false  # Uncomment to disable the `avoid_print` rule
     # prefer_single_quotes: true  # Uncomment to enable the `prefer_single_quotes` rule
-
 # Additional information about this file can be found at
 # https://dart.dev/guides/language/analysis-options

--- a/examples/simple_chat/android/app/src/debug/AndroidManifest.xml
+++ b/examples/simple_chat/android/app/src/debug/AndroidManifest.xml
@@ -1,4 +1,4 @@
-<!-- Copyright 2025 The Flutter Authors. All rights reserved.
+<!-- Copyright 2025 The Flutter Authors.
 Use of this source code is governed by a BSD-style license that can be
 found in the LICENSE file. -->
 

--- a/examples/simple_chat/android/app/src/main/AndroidManifest.xml
+++ b/examples/simple_chat/android/app/src/main/AndroidManifest.xml
@@ -1,4 +1,4 @@
-<!-- Copyright 2025 The Flutter Authors. All rights reserved.
+<!-- Copyright 2025 The Flutter Authors.
 Use of this source code is governed by a BSD-style license that can be
 found in the LICENSE file. -->
 

--- a/examples/simple_chat/android/app/src/main/kotlin/com/example/simple_chat/MainActivity.kt
+++ b/examples/simple_chat/android/app/src/main/kotlin/com/example/simple_chat/MainActivity.kt
@@ -1,4 +1,4 @@
-// Copyright 2025 The Flutter Authors. All rights reserved.
+// Copyright 2025 The Flutter Authors.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/examples/simple_chat/android/app/src/main/res/drawable-v21/launch_background.xml
+++ b/examples/simple_chat/android/app/src/main/res/drawable-v21/launch_background.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- Copyright 2025 The Flutter Authors. All rights reserved.
+<!-- Copyright 2025 The Flutter Authors.
 Use of this source code is governed by a BSD-style license that can be
 found in the LICENSE file. -->
 

--- a/examples/simple_chat/android/app/src/main/res/drawable/launch_background.xml
+++ b/examples/simple_chat/android/app/src/main/res/drawable/launch_background.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- Copyright 2025 The Flutter Authors. All rights reserved.
+<!-- Copyright 2025 The Flutter Authors.
 Use of this source code is governed by a BSD-style license that can be
 found in the LICENSE file. -->
 

--- a/examples/simple_chat/android/app/src/main/res/values-night/styles.xml
+++ b/examples/simple_chat/android/app/src/main/res/values-night/styles.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- Copyright 2025 The Flutter Authors. All rights reserved.
+<!-- Copyright 2025 The Flutter Authors.
 Use of this source code is governed by a BSD-style license that can be
 found in the LICENSE file. -->
 

--- a/examples/simple_chat/android/app/src/main/res/values/styles.xml
+++ b/examples/simple_chat/android/app/src/main/res/values/styles.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- Copyright 2025 The Flutter Authors. All rights reserved.
+<!-- Copyright 2025 The Flutter Authors.
 Use of this source code is governed by a BSD-style license that can be
 found in the LICENSE file. -->
 

--- a/examples/simple_chat/android/app/src/profile/AndroidManifest.xml
+++ b/examples/simple_chat/android/app/src/profile/AndroidManifest.xml
@@ -1,4 +1,4 @@
-<!-- Copyright 2025 The Flutter Authors. All rights reserved.
+<!-- Copyright 2025 The Flutter Authors.
 Use of this source code is governed by a BSD-style license that can be
 found in the LICENSE file. -->
 

--- a/examples/simple_chat/ios/Runner/AppDelegate.swift
+++ b/examples/simple_chat/ios/Runner/AppDelegate.swift
@@ -1,4 +1,4 @@
-// Copyright 2025 The Flutter Authors. All rights reserved.
+// Copyright 2025 The Flutter Authors.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/examples/simple_chat/ios/RunnerTests/RunnerTests.swift
+++ b/examples/simple_chat/ios/RunnerTests/RunnerTests.swift
@@ -1,4 +1,4 @@
-// Copyright 2025 The Flutter Authors. All rights reserved.
+// Copyright 2025 The Flutter Authors.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/examples/simple_chat/lib/firebase_options_stub.dart
+++ b/examples/simple_chat/lib/firebase_options_stub.dart
@@ -1,4 +1,4 @@
-// Copyright 2025 The Flutter Authors. All rights reserved.
+// Copyright 2025 The Flutter Authors.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/examples/simple_chat/lib/main.dart
+++ b/examples/simple_chat/lib/main.dart
@@ -1,4 +1,4 @@
-// Copyright 2025 The Flutter Authors. All rights reserved.
+// Copyright 2025 The Flutter Authors.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/examples/simple_chat/lib/message.dart
+++ b/examples/simple_chat/lib/message.dart
@@ -1,4 +1,4 @@
-// Copyright 2025 The Flutter Authors. All rights reserved.
+// Copyright 2025 The Flutter Authors.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/examples/simple_chat/macos/Runner/AppDelegate.swift
+++ b/examples/simple_chat/macos/Runner/AppDelegate.swift
@@ -1,4 +1,4 @@
-// Copyright 2025 The Flutter Authors. All rights reserved.
+// Copyright 2025 The Flutter Authors.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/examples/simple_chat/macos/Runner/Configs/AppInfo.xcconfig
+++ b/examples/simple_chat/macos/Runner/Configs/AppInfo.xcconfig
@@ -11,4 +11,4 @@ PRODUCT_NAME = simple_chat
 PRODUCT_BUNDLE_IDENTIFIER = com.example.simpleChat
 
 // The copyright displayed in application information
-PRODUCT_COPYRIGHT = Copyright © 2025 com.example. All rights reserved.
+PRODUCT_COPYRIGHT = Copyright © 2025 com.example.

--- a/examples/simple_chat/macos/Runner/MainFlutterWindow.swift
+++ b/examples/simple_chat/macos/Runner/MainFlutterWindow.swift
@@ -1,4 +1,4 @@
-// Copyright 2025 The Flutter Authors. All rights reserved.
+// Copyright 2025 The Flutter Authors.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/examples/simple_chat/macos/RunnerTests/RunnerTests.swift
+++ b/examples/simple_chat/macos/RunnerTests/RunnerTests.swift
@@ -1,4 +1,4 @@
-// Copyright 2025 The Flutter Authors. All rights reserved.
+// Copyright 2025 The Flutter Authors.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/examples/simple_chat/pubspec.yaml
+++ b/examples/simple_chat/pubspec.yaml
@@ -1,4 +1,4 @@
-# Copyright 2025 The Flutter Authors. All rights reserved.
+# Copyright 2025 The Flutter Authors.
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 

--- a/examples/simple_chat/web/index.html
+++ b/examples/simple_chat/web/index.html
@@ -1,10 +1,10 @@
 <!DOCTYPE html>
-<!-- Copyright 2025 The Flutter Authors. All rights reserved.
+<!-- Copyright 2025 The Flutter Authors.
 Use of this source code is governed by a BSD-style license that can be
 found in the LICENSE file. -->
 <html>
-<head>
-  <!--
+  <head>
+    <!--
     If you are serving your web app in a path other than the root, change the
     href value below to reflect the base path you are serving from.
 
@@ -17,25 +17,25 @@ found in the LICENSE file. -->
     This is a placeholder for base href that will be replaced by the value of
     the `--base-href` argument provided to `flutter build`.
   -->
-  <base href="$FLUTTER_BASE_HREF">
+    <base href="$FLUTTER_BASE_HREF" />
 
-  <meta charset="UTF-8">
-  <meta content="IE=Edge" http-equiv="X-UA-Compatible">
-  <meta name="description" content="A new Flutter project.">
+    <meta charset="UTF-8" />
+    <meta content="IE=Edge" http-equiv="X-UA-Compatible" />
+    <meta name="description" content="A new Flutter project." />
 
-  <!-- iOS meta tags & icons -->
-  <meta name="mobile-web-app-capable" content="yes">
-  <meta name="apple-mobile-web-app-status-bar-style" content="black">
-  <meta name="apple-mobile-web-app-title" content="simple_chat">
-  <link rel="apple-touch-icon" href="icons/Icon-192.png">
+    <!-- iOS meta tags & icons -->
+    <meta name="mobile-web-app-capable" content="yes" />
+    <meta name="apple-mobile-web-app-status-bar-style" content="black" />
+    <meta name="apple-mobile-web-app-title" content="simple_chat" />
+    <link rel="apple-touch-icon" href="icons/Icon-192.png" />
 
-  <!-- Favicon -->
-  <link rel="icon" type="image/png" href="favicon.png"/>
+    <!-- Favicon -->
+    <link rel="icon" type="image/png" href="favicon.png" />
 
-  <title>simple_chat</title>
-  <link rel="manifest" href="manifest.json">
-</head>
-<body>
-  <script src="flutter_bootstrap.js" async></script>
-</body>
+    <title>simple_chat</title>
+    <link rel="manifest" href="manifest.json" />
+  </head>
+  <body>
+    <script src="flutter_bootstrap.js" async></script>
+  </body>
 </html>

--- a/examples/simple_chat/windows/CMakeLists.txt
+++ b/examples/simple_chat/windows/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2025 The Flutter Authors. All rights reserved.
+# Copyright 2025 The Flutter Authors.
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 

--- a/examples/simple_chat/windows/flutter/CMakeLists.txt
+++ b/examples/simple_chat/windows/flutter/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2025 The Flutter Authors. All rights reserved.
+# Copyright 2025 The Flutter Authors.
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 

--- a/examples/simple_chat/windows/runner/CMakeLists.txt
+++ b/examples/simple_chat/windows/runner/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2025 The Flutter Authors. All rights reserved.
+# Copyright 2025 The Flutter Authors.
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 

--- a/examples/simple_chat/windows/runner/Runner.rc
+++ b/examples/simple_chat/windows/runner/Runner.rc
@@ -93,7 +93,7 @@ BEGIN
             VALUE "FileDescription", "simple_chat" "\0"
             VALUE "FileVersion", VERSION_AS_STRING "\0"
             VALUE "InternalName", "simple_chat" "\0"
-            VALUE "LegalCopyright", "Copyright (C) 2025 com.example. All rights reserved." "\0"
+            VALUE "LegalCopyright", "Copyright (C) 2025 com.example." "\0"
             VALUE "OriginalFilename", "simple_chat.exe" "\0"
             VALUE "ProductName", "simple_chat" "\0"
             VALUE "ProductVersion", VERSION_AS_STRING "\0"

--- a/examples/simple_chat/windows/runner/flutter_window.cpp
+++ b/examples/simple_chat/windows/runner/flutter_window.cpp
@@ -1,4 +1,4 @@
-// Copyright 2025 The Flutter Authors. All rights reserved.
+// Copyright 2025 The Flutter Authors.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/examples/simple_chat/windows/runner/flutter_window.h
+++ b/examples/simple_chat/windows/runner/flutter_window.h
@@ -1,4 +1,4 @@
-// Copyright 2025 The Flutter Authors. All rights reserved.
+// Copyright 2025 The Flutter Authors.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/examples/simple_chat/windows/runner/main.cpp
+++ b/examples/simple_chat/windows/runner/main.cpp
@@ -1,4 +1,4 @@
-// Copyright 2025 The Flutter Authors. All rights reserved.
+// Copyright 2025 The Flutter Authors.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/examples/simple_chat/windows/runner/resource.h
+++ b/examples/simple_chat/windows/runner/resource.h
@@ -1,4 +1,4 @@
-// Copyright 2025 The Flutter Authors. All rights reserved.
+// Copyright 2025 The Flutter Authors.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/examples/simple_chat/windows/runner/utils.cpp
+++ b/examples/simple_chat/windows/runner/utils.cpp
@@ -1,4 +1,4 @@
-// Copyright 2025 The Flutter Authors. All rights reserved.
+// Copyright 2025 The Flutter Authors.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/examples/simple_chat/windows/runner/utils.h
+++ b/examples/simple_chat/windows/runner/utils.h
@@ -1,4 +1,4 @@
-// Copyright 2025 The Flutter Authors. All rights reserved.
+// Copyright 2025 The Flutter Authors.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/examples/simple_chat/windows/runner/win32_window.cpp
+++ b/examples/simple_chat/windows/runner/win32_window.cpp
@@ -1,4 +1,4 @@
-// Copyright 2025 The Flutter Authors. All rights reserved.
+// Copyright 2025 The Flutter Authors.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/examples/simple_chat/windows/runner/win32_window.h
+++ b/examples/simple_chat/windows/runner/win32_window.h
@@ -1,4 +1,4 @@
-// Copyright 2025 The Flutter Authors. All rights reserved.
+// Copyright 2025 The Flutter Authors.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/examples/travel_app/analysis_options.yaml
+++ b/examples/travel_app/analysis_options.yaml
@@ -1,4 +1,4 @@
-# Copyright 2025 The Flutter Authors. All rights reserved.
+# Copyright 2025 The Flutter Authors.
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 

--- a/examples/travel_app/android/app/src/debug/AndroidManifest.xml
+++ b/examples/travel_app/android/app/src/debug/AndroidManifest.xml
@@ -1,4 +1,4 @@
-<!-- Copyright 2025 The Flutter Authors. All rights reserved.
+<!-- Copyright 2025 The Flutter Authors.
 Use of this source code is governed by a BSD-style license that can be
 found in the LICENSE file. -->
 

--- a/examples/travel_app/android/app/src/main/AndroidManifest.xml
+++ b/examples/travel_app/android/app/src/main/AndroidManifest.xml
@@ -1,4 +1,4 @@
-<!-- Copyright 2025 The Flutter Authors. All rights reserved.
+<!-- Copyright 2025 The Flutter Authors.
 Use of this source code is governed by a BSD-style license that can be
 found in the LICENSE file. -->
 

--- a/examples/travel_app/android/app/src/main/kotlin/dev/flutter/genui/genui_client/MainActivity.kt
+++ b/examples/travel_app/android/app/src/main/kotlin/dev/flutter/genui/genui_client/MainActivity.kt
@@ -1,4 +1,4 @@
-// Copyright 2025 The Flutter Authors. All rights reserved.
+// Copyright 2025 The Flutter Authors.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/examples/travel_app/android/app/src/main/res/drawable-v21/launch_background.xml
+++ b/examples/travel_app/android/app/src/main/res/drawable-v21/launch_background.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- Copyright 2025 The Flutter Authors. All rights reserved.
+<!-- Copyright 2025 The Flutter Authors.
 Use of this source code is governed by a BSD-style license that can be
 found in the LICENSE file. -->
 

--- a/examples/travel_app/android/app/src/main/res/drawable/launch_background.xml
+++ b/examples/travel_app/android/app/src/main/res/drawable/launch_background.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- Copyright 2025 The Flutter Authors. All rights reserved.
+<!-- Copyright 2025 The Flutter Authors.
 Use of this source code is governed by a BSD-style license that can be
 found in the LICENSE file. -->
 

--- a/examples/travel_app/android/app/src/main/res/values-night/styles.xml
+++ b/examples/travel_app/android/app/src/main/res/values-night/styles.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- Copyright 2025 The Flutter Authors. All rights reserved.
+<!-- Copyright 2025 The Flutter Authors.
 Use of this source code is governed by a BSD-style license that can be
 found in the LICENSE file. -->
 

--- a/examples/travel_app/android/app/src/main/res/values/styles.xml
+++ b/examples/travel_app/android/app/src/main/res/values/styles.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- Copyright 2025 The Flutter Authors. All rights reserved.
+<!-- Copyright 2025 The Flutter Authors.
 Use of this source code is governed by a BSD-style license that can be
 found in the LICENSE file. -->
 

--- a/examples/travel_app/android/app/src/profile/AndroidManifest.xml
+++ b/examples/travel_app/android/app/src/profile/AndroidManifest.xml
@@ -1,4 +1,4 @@
-<!-- Copyright 2025 The Flutter Authors. All rights reserved.
+<!-- Copyright 2025 The Flutter Authors.
 Use of this source code is governed by a BSD-style license that can be
 found in the LICENSE file. -->
 

--- a/examples/travel_app/integration_test/app_test.dart
+++ b/examples/travel_app/integration_test/app_test.dart
@@ -1,4 +1,4 @@
-// Copyright 2025 The Flutter Authors. All rights reserved.
+// Copyright 2025 The Flutter Authors.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/examples/travel_app/ios/Runner/AppDelegate.swift
+++ b/examples/travel_app/ios/Runner/AppDelegate.swift
@@ -1,4 +1,4 @@
-// Copyright 2025 The Flutter Authors. All rights reserved.
+// Copyright 2025 The Flutter Authors.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/examples/travel_app/ios/RunnerTests/RunnerTests.swift
+++ b/examples/travel_app/ios/RunnerTests/RunnerTests.swift
@@ -1,4 +1,4 @@
-// Copyright 2025 The Flutter Authors. All rights reserved.
+// Copyright 2025 The Flutter Authors.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/examples/travel_app/lib/firebase_options_stub.dart
+++ b/examples/travel_app/lib/firebase_options_stub.dart
@@ -1,4 +1,4 @@
-// Copyright 2025 The Flutter Authors. All rights reserved.
+// Copyright 2025 The Flutter Authors.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/examples/travel_app/lib/main.dart
+++ b/examples/travel_app/lib/main.dart
@@ -1,4 +1,4 @@
-// Copyright 2025 The Flutter Authors. All rights reserved.
+// Copyright 2025 The Flutter Authors.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/examples/travel_app/lib/src/asset_images.dart
+++ b/examples/travel_app/lib/src/asset_images.dart
@@ -1,4 +1,4 @@
-// Copyright 2025 The Flutter Authors. All rights reserved.
+// Copyright 2025 The Flutter Authors.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/examples/travel_app/lib/src/catalog.dart
+++ b/examples/travel_app/lib/src/catalog.dart
@@ -1,4 +1,4 @@
-// Copyright 2025 The Flutter Authors. All rights reserved.
+// Copyright 2025 The Flutter Authors.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/examples/travel_app/lib/src/catalog/checkbox_filter_chips_input.dart
+++ b/examples/travel_app/lib/src/catalog/checkbox_filter_chips_input.dart
@@ -1,4 +1,4 @@
-// Copyright 2025 The Flutter Authors. All rights reserved.
+// Copyright 2025 The Flutter Authors.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/examples/travel_app/lib/src/catalog/common.dart
+++ b/examples/travel_app/lib/src/catalog/common.dart
@@ -1,4 +1,4 @@
-// Copyright 2025 The Flutter Authors. All rights reserved.
+// Copyright 2025 The Flutter Authors.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/examples/travel_app/lib/src/catalog/information_card.dart
+++ b/examples/travel_app/lib/src/catalog/information_card.dart
@@ -1,4 +1,4 @@
-// Copyright 2025 The Flutter Authors. All rights reserved.
+// Copyright 2025 The Flutter Authors.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/examples/travel_app/lib/src/catalog/input_group.dart
+++ b/examples/travel_app/lib/src/catalog/input_group.dart
@@ -1,4 +1,4 @@
-// Copyright 2025 The Flutter Authors. All rights reserved.
+// Copyright 2025 The Flutter Authors.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/examples/travel_app/lib/src/catalog/itinerary_day.dart
+++ b/examples/travel_app/lib/src/catalog/itinerary_day.dart
@@ -1,4 +1,4 @@
-// Copyright 2025 The Flutter Authors. All rights reserved.
+// Copyright 2025 The Flutter Authors.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/examples/travel_app/lib/src/catalog/itinerary_entry.dart
+++ b/examples/travel_app/lib/src/catalog/itinerary_entry.dart
@@ -1,4 +1,4 @@
-// Copyright 2025 The Flutter Authors. All rights reserved.
+// Copyright 2025 The Flutter Authors.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/examples/travel_app/lib/src/catalog/itinerary_with_details.dart
+++ b/examples/travel_app/lib/src/catalog/itinerary_with_details.dart
@@ -1,4 +1,4 @@
-// Copyright 2025 The Flutter Authors. All rights reserved.
+// Copyright 2025 The Flutter Authors.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/examples/travel_app/lib/src/catalog/listings_booker.dart
+++ b/examples/travel_app/lib/src/catalog/listings_booker.dart
@@ -1,4 +1,4 @@
-// Copyright 2025 The Flutter Authors. All rights reserved.
+// Copyright 2025 The Flutter Authors.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/examples/travel_app/lib/src/catalog/options_filter_chip_input.dart
+++ b/examples/travel_app/lib/src/catalog/options_filter_chip_input.dart
@@ -1,4 +1,4 @@
-// Copyright 2025 The Flutter Authors. All rights reserved.
+// Copyright 2025 The Flutter Authors.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/examples/travel_app/lib/src/catalog/padded_body_text.dart
+++ b/examples/travel_app/lib/src/catalog/padded_body_text.dart
@@ -1,4 +1,4 @@
-// Copyright 2025 The Flutter Authors. All rights reserved.
+// Copyright 2025 The Flutter Authors.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/examples/travel_app/lib/src/catalog/section_header.dart
+++ b/examples/travel_app/lib/src/catalog/section_header.dart
@@ -1,4 +1,4 @@
-// Copyright 2025 The Flutter Authors. All rights reserved.
+// Copyright 2025 The Flutter Authors.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/examples/travel_app/lib/src/catalog/tabbed_sections.dart
+++ b/examples/travel_app/lib/src/catalog/tabbed_sections.dart
@@ -1,4 +1,4 @@
-// Copyright 2025 The Flutter Authors. All rights reserved.
+// Copyright 2025 The Flutter Authors.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/examples/travel_app/lib/src/catalog/text_input_chip.dart
+++ b/examples/travel_app/lib/src/catalog/text_input_chip.dart
@@ -1,4 +1,4 @@
-// Copyright 2025 The Flutter Authors. All rights reserved.
+// Copyright 2025 The Flutter Authors.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/examples/travel_app/lib/src/catalog/trailhead.dart
+++ b/examples/travel_app/lib/src/catalog/trailhead.dart
@@ -1,4 +1,4 @@
-// Copyright 2025 The Flutter Authors. All rights reserved.
+// Copyright 2025 The Flutter Authors.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/examples/travel_app/lib/src/catalog/travel_carousel.dart
+++ b/examples/travel_app/lib/src/catalog/travel_carousel.dart
@@ -1,4 +1,4 @@
-// Copyright 2025 The Flutter Authors. All rights reserved.
+// Copyright 2025 The Flutter Authors.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/examples/travel_app/lib/src/tools/booking/booking_service.dart
+++ b/examples/travel_app/lib/src/tools/booking/booking_service.dart
@@ -1,4 +1,4 @@
-// Copyright 2025 The Flutter Authors. All rights reserved.
+// Copyright 2025 The Flutter Authors.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/examples/travel_app/lib/src/tools/booking/list_hotels_tool.dart
+++ b/examples/travel_app/lib/src/tools/booking/list_hotels_tool.dart
@@ -1,4 +1,4 @@
-// Copyright 2025 The Flutter Authors. All rights reserved.
+// Copyright 2025 The Flutter Authors.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/examples/travel_app/lib/src/tools/booking/model.dart
+++ b/examples/travel_app/lib/src/tools/booking/model.dart
@@ -1,4 +1,4 @@
-// Copyright 2025 The Flutter Authors. All rights reserved.
+// Copyright 2025 The Flutter Authors.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/examples/travel_app/lib/src/travel_planner_page.dart
+++ b/examples/travel_app/lib/src/travel_planner_page.dart
@@ -1,4 +1,4 @@
-// Copyright 2025 The Flutter Authors. All rights reserved.
+// Copyright 2025 The Flutter Authors.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/examples/travel_app/lib/src/utils.dart
+++ b/examples/travel_app/lib/src/utils.dart
@@ -1,4 +1,4 @@
-// Copyright 2025 The Flutter Authors. All rights reserved.
+// Copyright 2025 The Flutter Authors.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/examples/travel_app/lib/src/widgets/conversation.dart
+++ b/examples/travel_app/lib/src/widgets/conversation.dart
@@ -1,4 +1,4 @@
-// Copyright 2025 The Flutter Authors. All rights reserved.
+// Copyright 2025 The Flutter Authors.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/examples/travel_app/lib/src/widgets/dismiss_notification.dart
+++ b/examples/travel_app/lib/src/widgets/dismiss_notification.dart
@@ -1,4 +1,4 @@
-// Copyright 2025 The Flutter Authors. All rights reserved.
+// Copyright 2025 The Flutter Authors.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/examples/travel_app/macos/Runner/AppDelegate.swift
+++ b/examples/travel_app/macos/Runner/AppDelegate.swift
@@ -1,4 +1,4 @@
-// Copyright 2025 The Flutter Authors. All rights reserved.
+// Copyright 2025 The Flutter Authors.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/examples/travel_app/macos/Runner/Configs/AppInfo.xcconfig
+++ b/examples/travel_app/macos/Runner/Configs/AppInfo.xcconfig
@@ -11,4 +11,4 @@ PRODUCT_NAME = genui_client
 PRODUCT_BUNDLE_IDENTIFIER = dev.flutter.genui.genuiClient
 
 // The copyright displayed in application information
-PRODUCT_COPYRIGHT = Copyright © 2025 dev.flutter.genui. All rights reserved.
+PRODUCT_COPYRIGHT = Copyright © 2025 dev.flutter.genui.

--- a/examples/travel_app/macos/Runner/MainFlutterWindow.swift
+++ b/examples/travel_app/macos/Runner/MainFlutterWindow.swift
@@ -1,4 +1,4 @@
-// Copyright 2025 The Flutter Authors. All rights reserved.
+// Copyright 2025 The Flutter Authors.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/examples/travel_app/macos/RunnerTests/RunnerTests.swift
+++ b/examples/travel_app/macos/RunnerTests/RunnerTests.swift
@@ -1,4 +1,4 @@
-// Copyright 2025 The Flutter Authors. All rights reserved.
+// Copyright 2025 The Flutter Authors.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/examples/travel_app/pubspec.yaml
+++ b/examples/travel_app/pubspec.yaml
@@ -1,4 +1,4 @@
-# Copyright 2025 The Flutter Authors. All rights reserved.
+# Copyright 2025 The Flutter Authors.
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 

--- a/examples/travel_app/test/asset_images_test.dart
+++ b/examples/travel_app/test/asset_images_test.dart
@@ -1,4 +1,4 @@
-// Copyright 2025 The Flutter Authors. All rights reserved.
+// Copyright 2025 The Flutter Authors.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/examples/travel_app/test/checkbox_filter_chips_input_test.dart
+++ b/examples/travel_app/test/checkbox_filter_chips_input_test.dart
@@ -1,4 +1,4 @@
-// Copyright 2025 The Flutter Authors. All rights reserved.
+// Copyright 2025 The Flutter Authors.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/examples/travel_app/test/image_catalog_test.dart
+++ b/examples/travel_app/test/image_catalog_test.dart
@@ -1,4 +1,4 @@
-// Copyright 2025 The Flutter Authors. All rights reserved.
+// Copyright 2025 The Flutter Authors.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/examples/travel_app/test/input_group_test.dart
+++ b/examples/travel_app/test/input_group_test.dart
@@ -1,4 +1,4 @@
-// Copyright 2025 The Flutter Authors. All rights reserved.
+// Copyright 2025 The Flutter Authors.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/examples/travel_app/test/itinerary_day_test.dart
+++ b/examples/travel_app/test/itinerary_day_test.dart
@@ -1,4 +1,4 @@
-// Copyright 2025 The Flutter Authors. All rights reserved.
+// Copyright 2025 The Flutter Authors.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/examples/travel_app/test/itinerary_entry_test.dart
+++ b/examples/travel_app/test/itinerary_entry_test.dart
@@ -1,4 +1,4 @@
-// Copyright 2025 The Flutter Authors. All rights reserved.
+// Copyright 2025 The Flutter Authors.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/examples/travel_app/test/itinerary_with_details_test.dart
+++ b/examples/travel_app/test/itinerary_with_details_test.dart
@@ -1,4 +1,4 @@
-// Copyright 2025 The Flutter Authors. All rights reserved.
+// Copyright 2025 The Flutter Authors.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/examples/travel_app/test/main_test.dart
+++ b/examples/travel_app/test/main_test.dart
@@ -1,4 +1,4 @@
-// Copyright 2025 The Flutter Authors. All rights reserved.
+// Copyright 2025 The Flutter Authors.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/examples/travel_app/test/options_filter_chip_input_test.dart
+++ b/examples/travel_app/test/options_filter_chip_input_test.dart
@@ -1,4 +1,4 @@
-// Copyright 2025 The Flutter Authors. All rights reserved.
+// Copyright 2025 The Flutter Authors.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/examples/travel_app/test/section_header_test.dart
+++ b/examples/travel_app/test/section_header_test.dart
@@ -1,4 +1,4 @@
-// Copyright 2025 The Flutter Authors. All rights reserved.
+// Copyright 2025 The Flutter Authors.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/examples/travel_app/test/tabbed_sections_test.dart
+++ b/examples/travel_app/test/tabbed_sections_test.dart
@@ -1,4 +1,4 @@
-// Copyright 2025 The Flutter Authors. All rights reserved.
+// Copyright 2025 The Flutter Authors.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/examples/travel_app/test/tools/hotels/list_hotels_tool_test.dart
+++ b/examples/travel_app/test/tools/hotels/list_hotels_tool_test.dart
@@ -1,4 +1,4 @@
-// Copyright 2025 The Flutter Authors. All rights reserved.
+// Copyright 2025 The Flutter Authors.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/examples/travel_app/test/trailhead_test.dart
+++ b/examples/travel_app/test/trailhead_test.dart
@@ -1,4 +1,4 @@
-// Copyright 2025 The Flutter Authors. All rights reserved.
+// Copyright 2025 The Flutter Authors.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/examples/travel_app/test/travel_carousel_test.dart
+++ b/examples/travel_app/test/travel_carousel_test.dart
@@ -1,4 +1,4 @@
-// Copyright 2025 The Flutter Authors. All rights reserved.
+// Copyright 2025 The Flutter Authors.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/examples/travel_app/test/widgets/conversation_test.dart
+++ b/examples/travel_app/test/widgets/conversation_test.dart
@@ -1,4 +1,4 @@
-// Copyright 2025 The Flutter Authors. All rights reserved.
+// Copyright 2025 The Flutter Authors.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/examples/travel_app/web/index.html
+++ b/examples/travel_app/web/index.html
@@ -1,10 +1,10 @@
 <!DOCTYPE html>
-<!-- Copyright 2025 The Flutter Authors. All rights reserved.
+<!-- Copyright 2025 The Flutter Authors.
 Use of this source code is governed by a BSD-style license that can be
 found in the LICENSE file. -->
 <html>
-<head>
-  <!--
+  <head>
+    <!--
     If you are serving your web app in a path other than the root, change the
     href value below to reflect the base path you are serving from.
 
@@ -17,25 +17,25 @@ found in the LICENSE file. -->
     This is a placeholder for base href that will be replaced by the value of
     the `--base-href` argument provided to `flutter build`.
   -->
-  <base href="$FLUTTER_BASE_HREF">
+    <base href="$FLUTTER_BASE_HREF" />
 
-  <meta charset="UTF-8">
-  <meta content="IE=Edge" http-equiv="X-UA-Compatible">
-  <meta name="description" content="A new Flutter project.">
+    <meta charset="UTF-8" />
+    <meta content="IE=Edge" http-equiv="X-UA-Compatible" />
+    <meta name="description" content="A new Flutter project." />
 
-  <!-- iOS meta tags & icons -->
-  <meta name="mobile-web-app-capable" content="yes">
-  <meta name="apple-mobile-web-app-status-bar-style" content="black">
-  <meta name="apple-mobile-web-app-title" content="genui_client">
-  <link rel="apple-touch-icon" href="icons/Icon-192.png">
+    <!-- iOS meta tags & icons -->
+    <meta name="mobile-web-app-capable" content="yes" />
+    <meta name="apple-mobile-web-app-status-bar-style" content="black" />
+    <meta name="apple-mobile-web-app-title" content="genui_client" />
+    <link rel="apple-touch-icon" href="icons/Icon-192.png" />
 
-  <!-- Favicon -->
-  <link rel="icon" type="image/png" href="favicon.png"/>
+    <!-- Favicon -->
+    <link rel="icon" type="image/png" href="favicon.png" />
 
-  <title>genui_client</title>
-  <link rel="manifest" href="manifest.json">
-</head>
-<body>
-  <script src="flutter_bootstrap.js" async></script>
-</body>
+    <title>genui_client</title>
+    <link rel="manifest" href="manifest.json" />
+  </head>
+  <body>
+    <script src="flutter_bootstrap.js" async></script>
+  </body>
 </html>

--- a/examples/travel_app/windows/CMakeLists.txt
+++ b/examples/travel_app/windows/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2025 The Flutter Authors. All rights reserved.
+# Copyright 2025 The Flutter Authors.
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 

--- a/examples/travel_app/windows/flutter/CMakeLists.txt
+++ b/examples/travel_app/windows/flutter/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2025 The Flutter Authors. All rights reserved.
+# Copyright 2025 The Flutter Authors.
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 

--- a/examples/travel_app/windows/runner/CMakeLists.txt
+++ b/examples/travel_app/windows/runner/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2025 The Flutter Authors. All rights reserved.
+# Copyright 2025 The Flutter Authors.
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 

--- a/examples/travel_app/windows/runner/Runner.rc
+++ b/examples/travel_app/windows/runner/Runner.rc
@@ -93,7 +93,7 @@ BEGIN
             VALUE "FileDescription", "genui_client" "\0"
             VALUE "FileVersion", VERSION_AS_STRING "\0"
             VALUE "InternalName", "genui_client" "\0"
-            VALUE "LegalCopyright", "Copyright (C) 2025 dev.flutter.genui. All rights reserved." "\0"
+            VALUE "LegalCopyright", "Copyright (C) 2025 dev.flutter.genui." "\0"
             VALUE "OriginalFilename", "genui_client.exe" "\0"
             VALUE "ProductName", "genui_client" "\0"
             VALUE "ProductVersion", VERSION_AS_STRING "\0"

--- a/examples/travel_app/windows/runner/flutter_window.cpp
+++ b/examples/travel_app/windows/runner/flutter_window.cpp
@@ -1,4 +1,4 @@
-// Copyright 2025 The Flutter Authors. All rights reserved.
+// Copyright 2025 The Flutter Authors.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/examples/travel_app/windows/runner/flutter_window.h
+++ b/examples/travel_app/windows/runner/flutter_window.h
@@ -1,4 +1,4 @@
-// Copyright 2025 The Flutter Authors. All rights reserved.
+// Copyright 2025 The Flutter Authors.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/examples/travel_app/windows/runner/main.cpp
+++ b/examples/travel_app/windows/runner/main.cpp
@@ -1,4 +1,4 @@
-// Copyright 2025 The Flutter Authors. All rights reserved.
+// Copyright 2025 The Flutter Authors.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/examples/travel_app/windows/runner/resource.h
+++ b/examples/travel_app/windows/runner/resource.h
@@ -1,4 +1,4 @@
-// Copyright 2025 The Flutter Authors. All rights reserved.
+// Copyright 2025 The Flutter Authors.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/examples/travel_app/windows/runner/utils.cpp
+++ b/examples/travel_app/windows/runner/utils.cpp
@@ -1,4 +1,4 @@
-// Copyright 2025 The Flutter Authors. All rights reserved.
+// Copyright 2025 The Flutter Authors.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/examples/travel_app/windows/runner/utils.h
+++ b/examples/travel_app/windows/runner/utils.h
@@ -1,4 +1,4 @@
-// Copyright 2025 The Flutter Authors. All rights reserved.
+// Copyright 2025 The Flutter Authors.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/examples/travel_app/windows/runner/win32_window.cpp
+++ b/examples/travel_app/windows/runner/win32_window.cpp
@@ -1,4 +1,4 @@
-// Copyright 2025 The Flutter Authors. All rights reserved.
+// Copyright 2025 The Flutter Authors.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/examples/travel_app/windows/runner/win32_window.h
+++ b/examples/travel_app/windows/runner/win32_window.h
@@ -1,4 +1,4 @@
-// Copyright 2025 The Flutter Authors. All rights reserved.
+// Copyright 2025 The Flutter Authors.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/packages/dart_schema_builder/analysis_options.yaml
+++ b/packages/dart_schema_builder/analysis_options.yaml
@@ -1,4 +1,4 @@
-# Copyright 2025 The Flutter Authors. All rights reserved.
+# Copyright 2025 The Flutter Authors.
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 

--- a/packages/dart_schema_builder/bin/schema_validator.dart
+++ b/packages/dart_schema_builder/bin/schema_validator.dart
@@ -1,4 +1,4 @@
-// Copyright 2025 The Flutter Authors. All rights reserved.
+// Copyright 2025 The Flutter Authors.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/packages/dart_schema_builder/example/build_and_validate_schema.dart
+++ b/packages/dart_schema_builder/example/build_and_validate_schema.dart
@@ -1,4 +1,4 @@
-// Copyright 2025 The Flutter Authors. All rights reserved.
+// Copyright 2025 The Flutter Authors.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/packages/dart_schema_builder/lib/dart_schema_builder.dart
+++ b/packages/dart_schema_builder/lib/dart_schema_builder.dart
@@ -1,4 +1,4 @@
-// Copyright 2025 The Flutter Authors. All rights reserved.
+// Copyright 2025 The Flutter Authors.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/packages/dart_schema_builder/lib/src/constants.dart
+++ b/packages/dart_schema_builder/lib/src/constants.dart
@@ -1,4 +1,4 @@
-// Copyright 2025 The Flutter Authors. All rights reserved.
+// Copyright 2025 The Flutter Authors.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/packages/dart_schema_builder/lib/src/formats.dart
+++ b/packages/dart_schema_builder/lib/src/formats.dart
@@ -1,4 +1,4 @@
-// Copyright 2025 The Flutter Authors. All rights reserved.
+// Copyright 2025 The Flutter Authors.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/packages/dart_schema_builder/lib/src/json_type.dart
+++ b/packages/dart_schema_builder/lib/src/json_type.dart
@@ -1,10 +1,6 @@
-// Copyright 2025 The Flutter Authors. All rights reserved.
+// Copyright 2025 The Flutter Authors.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
-
-// Copyright (c) 2025, the Dart project authors.  Please see the AUTHORS file
-// for details. All rights reserved. Use of this source code is governed by a
-// BSD-style license that can be found in the LICENSE file.
 
 /// The valid types for properties in a JSON schema.
 enum JsonType {

--- a/packages/dart_schema_builder/lib/src/logging_context.dart
+++ b/packages/dart_schema_builder/lib/src/logging_context.dart
@@ -1,4 +1,4 @@
-// Copyright 2025 The Flutter Authors. All rights reserved.
+// Copyright 2025 The Flutter Authors.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/packages/dart_schema_builder/lib/src/schema/boolean_schema.dart
+++ b/packages/dart_schema_builder/lib/src/schema/boolean_schema.dart
@@ -1,4 +1,4 @@
-// Copyright 2025 The Flutter Authors. All rights reserved.
+// Copyright 2025 The Flutter Authors.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/packages/dart_schema_builder/lib/src/schema/integer_schema.dart
+++ b/packages/dart_schema_builder/lib/src/schema/integer_schema.dart
@@ -1,4 +1,4 @@
-// Copyright 2025 The Flutter Authors. All rights reserved.
+// Copyright 2025 The Flutter Authors.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/packages/dart_schema_builder/lib/src/schema/list_schema.dart
+++ b/packages/dart_schema_builder/lib/src/schema/list_schema.dart
@@ -1,4 +1,4 @@
-// Copyright 2025 The Flutter Authors. All rights reserved.
+// Copyright 2025 The Flutter Authors.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/packages/dart_schema_builder/lib/src/schema/null_schema.dart
+++ b/packages/dart_schema_builder/lib/src/schema/null_schema.dart
@@ -1,4 +1,4 @@
-// Copyright 2025 The Flutter Authors. All rights reserved.
+// Copyright 2025 The Flutter Authors.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/packages/dart_schema_builder/lib/src/schema/number_schema.dart
+++ b/packages/dart_schema_builder/lib/src/schema/number_schema.dart
@@ -1,4 +1,4 @@
-// Copyright 2025 The Flutter Authors. All rights reserved.
+// Copyright 2025 The Flutter Authors.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/packages/dart_schema_builder/lib/src/schema/object_schema.dart
+++ b/packages/dart_schema_builder/lib/src/schema/object_schema.dart
@@ -1,10 +1,6 @@
-// Copyright 2025 The Flutter Authors. All rights reserved.
+// Copyright 2025 The Flutter Authors.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
-
-// Copyright (c) 2025, the Dart project authors  Please see the AUTHORS file
-// for details. All rights reserved. Use of this source code is governed by a
-// BSD-style license that can be found in the LICENSE file.
 
 import '../constants.dart';
 import '../json_type.dart';

--- a/packages/dart_schema_builder/lib/src/schema/schema.dart
+++ b/packages/dart_schema_builder/lib/src/schema/schema.dart
@@ -1,4 +1,4 @@
-// Copyright 2025 The Flutter Authors. All rights reserved.
+// Copyright 2025 The Flutter Authors.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/packages/dart_schema_builder/lib/src/schema/string_schema.dart
+++ b/packages/dart_schema_builder/lib/src/schema/string_schema.dart
@@ -1,10 +1,6 @@
-// Copyright 2025 The Flutter Authors. All rights reserved.
+// Copyright 2025 The Flutter Authors.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
-
-// Copyright (c) 2025, the Dart project authors.  Please see the AUTHORS file
-// for details. All rights reserved. Use of a source code is governed by a
-// BSD-style license that can be found in the LICENSE file.
 
 import '../constants.dart';
 import '../json_type.dart';

--- a/packages/dart_schema_builder/lib/src/schema_cache.dart
+++ b/packages/dart_schema_builder/lib/src/schema_cache.dart
@@ -1,4 +1,4 @@
-// Copyright 2025 The Flutter Authors. All rights reserved.
+// Copyright 2025 The Flutter Authors.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/packages/dart_schema_builder/lib/src/schema_registry.dart
+++ b/packages/dart_schema_builder/lib/src/schema_registry.dart
@@ -1,4 +1,4 @@
-// Copyright 2025 The Flutter Authors. All rights reserved.
+// Copyright 2025 The Flutter Authors.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/packages/dart_schema_builder/lib/src/schema_validation.dart
+++ b/packages/dart_schema_builder/lib/src/schema_validation.dart
@@ -1,4 +1,4 @@
-// Copyright 2025 The Flutter Authors. All rights reserved.
+// Copyright 2025 The Flutter Authors.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/packages/dart_schema_builder/lib/src/utils.dart
+++ b/packages/dart_schema_builder/lib/src/utils.dart
@@ -1,4 +1,4 @@
-// Copyright 2025 The Flutter Authors. All rights reserved.
+// Copyright 2025 The Flutter Authors.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/packages/dart_schema_builder/lib/src/validation_error.dart
+++ b/packages/dart_schema_builder/lib/src/validation_error.dart
@@ -1,10 +1,6 @@
-// Copyright 2025 The Flutter Authors. All rights reserved.
+// Copyright 2025 The Flutter Authors.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
-
-// Copyright (c) 2025, the Dart project authors.  Please see the AUTHORS file
-// for details. All rights reserved. Use of this source code is governed by a
-// BSD-style license that can be found in the LICENSE file.
 
 /// Enum representing the types of validation failures when checking data
 /// against a schema.

--- a/packages/dart_schema_builder/lib/src/validation_result.dart
+++ b/packages/dart_schema_builder/lib/src/validation_result.dart
@@ -1,4 +1,4 @@
-// Copyright 2025 The Flutter Authors. All rights reserved.
+// Copyright 2025 The Flutter Authors.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/packages/dart_schema_builder/pubspec.yaml
+++ b/packages/dart_schema_builder/pubspec.yaml
@@ -1,4 +1,4 @@
-# Copyright 2025 The Flutter Authors. All rights reserved.
+# Copyright 2025 The Flutter Authors.
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 

--- a/packages/dart_schema_builder/test/schema_cache_test.dart
+++ b/packages/dart_schema_builder/test/schema_cache_test.dart
@@ -1,4 +1,4 @@
-// Copyright 2025 The Flutter Authors. All rights reserved.
+// Copyright 2025 The Flutter Authors.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/packages/dart_schema_builder/test/schema_cache_test.mocks.dart
+++ b/packages/dart_schema_builder/test/schema_cache_test.mocks.dart
@@ -1,4 +1,4 @@
-// Copyright 2025 The Flutter Authors. All rights reserved.
+// Copyright 2025 The Flutter Authors.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/packages/dart_schema_builder/test/schema_test.dart
+++ b/packages/dart_schema_builder/test/schema_test.dart
@@ -1,10 +1,6 @@
-// Copyright 2025 The Flutter Authors. All rights reserved.
+// Copyright 2025 The Flutter Authors.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
-
-// Copyright (c) 2025, the Dart project authors.  Please see the AUTHORS file
-// for details. All rights reserved. Use of this source code is governed by a
-// BSD-style license that can be found in the LICENSE file.
 
 // ignore_for_file: lines_longer_than_80_chars
 

--- a/packages/dart_schema_builder/test/test_suite_test.dart
+++ b/packages/dart_schema_builder/test/test_suite_test.dart
@@ -1,4 +1,4 @@
-// Copyright 2025 The Flutter Authors. All rights reserved.
+// Copyright 2025 The Flutter Authors.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/packages/flutter_genui/LICENSE
+++ b/packages/flutter_genui/LICENSE
@@ -1,4 +1,4 @@
-Copyright 2025 The Flutter Authors. All rights reserved.
+Copyright 2025 The Flutter Authors.
 
 Redistribution and use in source and binary forms, with or without modification,
 are permitted provided that the following conditions are met:

--- a/packages/flutter_genui/analysis_options.yaml
+++ b/packages/flutter_genui/analysis_options.yaml
@@ -1,8 +1,7 @@
-# Copyright 2025 The Flutter Authors. All rights reserved.
+# Copyright 2025 The Flutter Authors.
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 
 include: package:dart_flutter_team_lints/analysis_options.yaml
-
 # Additional information about this file can be found at
 # https://dart.dev/guides/language/analysis-options

--- a/packages/flutter_genui/lib/flutter_genui.dart
+++ b/packages/flutter_genui/lib/flutter_genui.dart
@@ -1,4 +1,4 @@
-// Copyright 2025 The Flutter Authors. All rights reserved.
+// Copyright 2025 The Flutter Authors.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/packages/flutter_genui/lib/flutter_genui_dev.dart
+++ b/packages/flutter_genui/lib/flutter_genui_dev.dart
@@ -1,4 +1,4 @@
-// Copyright 2025 The Flutter Authors. All rights reserved.
+// Copyright 2025 The Flutter Authors.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/packages/flutter_genui/lib/src/ai_client/ai_client.dart
+++ b/packages/flutter_genui/lib/src/ai_client/ai_client.dart
@@ -1,4 +1,4 @@
-// Copyright 2025 The Flutter Authors. All rights reserved.
+// Copyright 2025 The Flutter Authors.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/packages/flutter_genui/lib/src/catalog/core_widgets/checkbox_group.dart
+++ b/packages/flutter_genui/lib/src/catalog/core_widgets/checkbox_group.dart
@@ -1,4 +1,4 @@
-// Copyright 2025 The Flutter Authors. All rights reserved.
+// Copyright 2025 The Flutter Authors.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/packages/flutter_genui/lib/src/catalog/core_widgets/column.dart
+++ b/packages/flutter_genui/lib/src/catalog/core_widgets/column.dart
@@ -1,4 +1,4 @@
-// Copyright 2025 The Flutter Authors. All rights reserved.
+// Copyright 2025 The Flutter Authors.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/packages/flutter_genui/lib/src/catalog/core_widgets/elevated_button.dart
+++ b/packages/flutter_genui/lib/src/catalog/core_widgets/elevated_button.dart
@@ -1,4 +1,4 @@
-// Copyright 2025 The Flutter Authors. All rights reserved.
+// Copyright 2025 The Flutter Authors.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/packages/flutter_genui/lib/src/catalog/core_widgets/image.dart
+++ b/packages/flutter_genui/lib/src/catalog/core_widgets/image.dart
@@ -1,4 +1,4 @@
-// Copyright 2025 The Flutter Authors. All rights reserved.
+// Copyright 2025 The Flutter Authors.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/packages/flutter_genui/lib/src/catalog/core_widgets/radio_group.dart
+++ b/packages/flutter_genui/lib/src/catalog/core_widgets/radio_group.dart
@@ -1,4 +1,4 @@
-// Copyright 2025 The Flutter Authors. All rights reserved.
+// Copyright 2025 The Flutter Authors.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/packages/flutter_genui/lib/src/catalog/core_widgets/text.dart
+++ b/packages/flutter_genui/lib/src/catalog/core_widgets/text.dart
@@ -1,4 +1,4 @@
-// Copyright 2025 The Flutter Authors. All rights reserved.
+// Copyright 2025 The Flutter Authors.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/packages/flutter_genui/lib/src/catalog/core_widgets/text_field.dart
+++ b/packages/flutter_genui/lib/src/catalog/core_widgets/text_field.dart
@@ -1,4 +1,4 @@
-// Copyright 2025 The Flutter Authors. All rights reserved.
+// Copyright 2025 The Flutter Authors.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/packages/flutter_genui/lib/src/core/core_catalog.dart
+++ b/packages/flutter_genui/lib/src/core/core_catalog.dart
@@ -1,4 +1,4 @@
-// Copyright 2025 The Flutter Authors. All rights reserved.
+// Copyright 2025 The Flutter Authors.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/packages/flutter_genui/lib/src/core/genui_configuration.dart
+++ b/packages/flutter_genui/lib/src/core/genui_configuration.dart
@@ -1,4 +1,4 @@
-// Copyright 2025 The Flutter Authors. All rights reserved.
+// Copyright 2025 The Flutter Authors.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/packages/flutter_genui/lib/src/core/genui_manager.dart
+++ b/packages/flutter_genui/lib/src/core/genui_manager.dart
@@ -1,4 +1,4 @@
-// Copyright 2025 The Flutter Authors. All rights reserved.
+// Copyright 2025 The Flutter Authors.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/packages/flutter_genui/lib/src/core/genui_surface.dart
+++ b/packages/flutter_genui/lib/src/core/genui_surface.dart
@@ -1,4 +1,4 @@
-// Copyright 2025 The Flutter Authors. All rights reserved.
+// Copyright 2025 The Flutter Authors.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/packages/flutter_genui/lib/src/core/prompt_fragments.dart
+++ b/packages/flutter_genui/lib/src/core/prompt_fragments.dart
@@ -1,4 +1,4 @@
-// Copyright 2025 The Flutter Authors. All rights reserved.
+// Copyright 2025 The Flutter Authors.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/packages/flutter_genui/lib/src/core/ui_tools.dart
+++ b/packages/flutter_genui/lib/src/core/ui_tools.dart
@@ -1,4 +1,4 @@
-// Copyright 2025 The Flutter Authors. All rights reserved.
+// Copyright 2025 The Flutter Authors.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/packages/flutter_genui/lib/src/core/widgets/chat_primitives.dart
+++ b/packages/flutter_genui/lib/src/core/widgets/chat_primitives.dart
@@ -1,4 +1,4 @@
-// Copyright 2025 The Flutter Authors. All rights reserved.
+// Copyright 2025 The Flutter Authors.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/packages/flutter_genui/lib/src/development_utilities/catalog_view.dart
+++ b/packages/flutter_genui/lib/src/development_utilities/catalog_view.dart
@@ -1,4 +1,4 @@
-// Copyright 2025 The Flutter Authors. All rights reserved.
+// Copyright 2025 The Flutter Authors.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/packages/flutter_genui/lib/src/facade/ui_agent.dart
+++ b/packages/flutter_genui/lib/src/facade/ui_agent.dart
@@ -1,4 +1,4 @@
-// Copyright 2025 The Flutter Authors. All rights reserved.
+// Copyright 2025 The Flutter Authors.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/packages/flutter_genui/lib/src/model/catalog.dart
+++ b/packages/flutter_genui/lib/src/model/catalog.dart
@@ -1,4 +1,4 @@
-// Copyright 2025 The Flutter Authors. All rights reserved.
+// Copyright 2025 The Flutter Authors.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/packages/flutter_genui/lib/src/model/catalog_item.dart
+++ b/packages/flutter_genui/lib/src/model/catalog_item.dart
@@ -1,4 +1,4 @@
-// Copyright 2025 The Flutter Authors. All rights reserved.
+// Copyright 2025 The Flutter Authors.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/packages/flutter_genui/lib/src/model/chat_message.dart
+++ b/packages/flutter_genui/lib/src/model/chat_message.dart
@@ -1,4 +1,4 @@
-// Copyright 2025 The Flutter Authors. All rights reserved.
+// Copyright 2025 The Flutter Authors.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/packages/flutter_genui/lib/src/model/tools.dart
+++ b/packages/flutter_genui/lib/src/model/tools.dart
@@ -1,4 +1,4 @@
-// Copyright 2025 The Flutter Authors. All rights reserved.
+// Copyright 2025 The Flutter Authors.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/packages/flutter_genui/lib/src/model/ui_models.dart
+++ b/packages/flutter_genui/lib/src/model/ui_models.dart
@@ -1,4 +1,4 @@
-// Copyright 2025 The Flutter Authors. All rights reserved.
+// Copyright 2025 The Flutter Authors.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/packages/flutter_genui/lib/src/primitives/logging.dart
+++ b/packages/flutter_genui/lib/src/primitives/logging.dart
@@ -1,4 +1,4 @@
-// Copyright 2025 The Flutter Authors. All rights reserved.
+// Copyright 2025 The Flutter Authors.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/packages/flutter_genui/lib/src/primitives/simple_items.dart
+++ b/packages/flutter_genui/lib/src/primitives/simple_items.dart
@@ -1,4 +1,4 @@
-// Copyright 2025 The Flutter Authors. All rights reserved.
+// Copyright 2025 The Flutter Authors.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/packages/flutter_genui/lib/test.dart
+++ b/packages/flutter_genui/lib/test.dart
@@ -1,4 +1,4 @@
-// Copyright 2025 The Flutter Authors. All rights reserved.
+// Copyright 2025 The Flutter Authors.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/packages/flutter_genui/lib/test/fake_ai_client.dart
+++ b/packages/flutter_genui/lib/test/fake_ai_client.dart
@@ -1,4 +1,4 @@
-// Copyright 2025 The Flutter Authors. All rights reserved.
+// Copyright 2025 The Flutter Authors.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/packages/flutter_genui/pubspec.yaml
+++ b/packages/flutter_genui/pubspec.yaml
@@ -1,4 +1,4 @@
-# Copyright 2025 The Flutter Authors. All rights reserved.
+# Copyright 2025 The Flutter Authors.
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 

--- a/packages/flutter_genui/test/ai_client/tools_test.dart
+++ b/packages/flutter_genui/test/ai_client/tools_test.dart
@@ -1,4 +1,4 @@
-// Copyright 2025 The Flutter Authors. All rights reserved.
+// Copyright 2025 The Flutter Authors.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/packages/flutter_genui/test/catalog/core_widgets_test.dart
+++ b/packages/flutter_genui/test/catalog/core_widgets_test.dart
@@ -1,4 +1,4 @@
-// Copyright 2025 The Flutter Authors. All rights reserved.
+// Copyright 2025 The Flutter Authors.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/packages/flutter_genui/test/core/genui_manager_test.dart
+++ b/packages/flutter_genui/test/core/genui_manager_test.dart
@@ -1,4 +1,4 @@
-// Copyright 2025 The Flutter Authors. All rights reserved.
+// Copyright 2025 The Flutter Authors.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/packages/flutter_genui/test/core/surface_widget_test.dart
+++ b/packages/flutter_genui/test/core/surface_widget_test.dart
@@ -1,4 +1,4 @@
-// Copyright 2025 The Flutter Authors. All rights reserved.
+// Copyright 2025 The Flutter Authors.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/packages/flutter_genui/test/core/ui_tools_test.dart
+++ b/packages/flutter_genui/test/core/ui_tools_test.dart
@@ -1,4 +1,4 @@
-// Copyright 2025 The Flutter Authors. All rights reserved.
+// Copyright 2025 The Flutter Authors.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/packages/flutter_genui/test/genui_surface_test.dart
+++ b/packages/flutter_genui/test/genui_surface_test.dart
@@ -1,4 +1,4 @@
-// Copyright 2025 The Flutter Authors. All rights reserved.
+// Copyright 2025 The Flutter Authors.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/packages/flutter_genui/test/genui_test.dart
+++ b/packages/flutter_genui/test/genui_test.dart
@@ -1,4 +1,4 @@
-// Copyright 2025 The Flutter Authors. All rights reserved.
+// Copyright 2025 The Flutter Authors.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/packages/flutter_genui/test/image_test.dart
+++ b/packages/flutter_genui/test/image_test.dart
@@ -1,4 +1,4 @@
-// Copyright 2025 The Flutter Authors. All rights reserved.
+// Copyright 2025 The Flutter Authors.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/packages/flutter_genui/test/model/ui_models_test.dart
+++ b/packages/flutter_genui/test/model/ui_models_test.dart
@@ -1,4 +1,4 @@
-// Copyright 2025 The Flutter Authors. All rights reserved.
+// Copyright 2025 The Flutter Authors.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/packages/flutter_genui_firebase_ai/LICENSE
+++ b/packages/flutter_genui_firebase_ai/LICENSE
@@ -1,4 +1,4 @@
-Copyright 2025 The Flutter Authors. All rights reserved.
+Copyright 2025 The Flutter Authors.
 
 Redistribution and use in source and binary forms, with or without modification,
 are permitted provided that the following conditions are met:

--- a/packages/flutter_genui_firebase_ai/analysis_options.yaml
+++ b/packages/flutter_genui_firebase_ai/analysis_options.yaml
@@ -1,8 +1,7 @@
-# Copyright 2025 The Flutter Authors. All rights reserved.
+# Copyright 2025 The Flutter Authors.
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 
 include: package:dart_flutter_team_lints/analysis_options.yaml
-
 # Additional information about this file can be found at
 # https://dart.dev/guides/language/analysis-options

--- a/packages/flutter_genui_firebase_ai/lib/flutter_genui_firebase_ai.dart
+++ b/packages/flutter_genui_firebase_ai/lib/flutter_genui_firebase_ai.dart
@@ -1,4 +1,4 @@
-// Copyright 2025 The Flutter Authors. All rights reserved.
+// Copyright 2025 The Flutter Authors.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/packages/flutter_genui_firebase_ai/lib/src/firebase_ai_client.dart
+++ b/packages/flutter_genui_firebase_ai/lib/src/firebase_ai_client.dart
@@ -1,4 +1,4 @@
-// Copyright 2025 The Flutter Authors. All rights reserved.
+// Copyright 2025 The Flutter Authors.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/packages/flutter_genui_firebase_ai/lib/src/gemini_content_converter.dart
+++ b/packages/flutter_genui_firebase_ai/lib/src/gemini_content_converter.dart
@@ -1,4 +1,4 @@
-// Copyright 2025 The Flutter Authors. All rights reserved.
+// Copyright 2025 The Flutter Authors.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/packages/flutter_genui_firebase_ai/lib/src/gemini_generative_model.dart
+++ b/packages/flutter_genui_firebase_ai/lib/src/gemini_generative_model.dart
@@ -1,4 +1,4 @@
-// Copyright 2025 The Flutter Authors. All rights reserved.
+// Copyright 2025 The Flutter Authors.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/packages/flutter_genui_firebase_ai/lib/src/gemini_schema_adapter.dart
+++ b/packages/flutter_genui_firebase_ai/lib/src/gemini_schema_adapter.dart
@@ -1,4 +1,4 @@
-// Copyright 2025 The Flutter Authors. All rights reserved.
+// Copyright 2025 The Flutter Authors.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/packages/flutter_genui_firebase_ai/pubspec.yaml
+++ b/packages/flutter_genui_firebase_ai/pubspec.yaml
@@ -1,4 +1,4 @@
-# Copyright 2025 The Flutter Authors. All rights reserved.
+# Copyright 2025 The Flutter Authors.
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 

--- a/packages/flutter_genui_firebase_ai/test/firebase_ai_client_test.dart
+++ b/packages/flutter_genui_firebase_ai/test/firebase_ai_client_test.dart
@@ -1,4 +1,4 @@
-// Copyright 2025 The Flutter Authors. All rights reserved.
+// Copyright 2025 The Flutter Authors.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/packages/flutter_genui_firebase_ai/test/gemini_content_converter_test.dart
+++ b/packages/flutter_genui_firebase_ai/test/gemini_content_converter_test.dart
@@ -1,4 +1,4 @@
-// Copyright 2025 The Flutter Authors. All rights reserved.
+// Copyright 2025 The Flutter Authors.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/packages/flutter_genui_firebase_ai/test/gemini_schema_adapter_test.dart
+++ b/packages/flutter_genui_firebase_ai/test/gemini_schema_adapter_test.dart
@@ -1,4 +1,4 @@
-// Copyright 2025 The Flutter Authors. All rights reserved.
+// Copyright 2025 The Flutter Authors.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/packages/flutter_genui_firebase_ai/test/test_infra/utils.dart
+++ b/packages/flutter_genui_firebase_ai/test/test_infra/utils.dart
@@ -1,4 +1,4 @@
-// Copyright 2025 The Flutter Authors. All rights reserved.
+// Copyright 2025 The Flutter Authors.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/packages/spikes/fcp_client/LICENSE
+++ b/packages/spikes/fcp_client/LICENSE
@@ -1,4 +1,4 @@
-Copyright 2025 The Flutter Authors. All rights reserved.
+Copyright 2025 The Flutter Authors.
 
 Redistribution and use in source and binary forms, with or without modification,
 are permitted provided that the following conditions are met:

--- a/packages/spikes/fcp_client/analysis_options.yaml
+++ b/packages/spikes/fcp_client/analysis_options.yaml
@@ -1,4 +1,4 @@
-# Copyright 2025 The Flutter Authors. All rights reserved.
+# Copyright 2025 The Flutter Authors.
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 

--- a/packages/spikes/fcp_client/example/analysis_options.yaml
+++ b/packages/spikes/fcp_client/example/analysis_options.yaml
@@ -1,4 +1,4 @@
-# Copyright 2025 The Flutter Authors. All rights reserved.
+# Copyright 2025 The Flutter Authors.
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 
@@ -27,6 +27,5 @@ linter:
   rules:
     # avoid_print: false  # Uncomment to disable the `avoid_print` rule
     # prefer_single_quotes: true  # Uncomment to enable the `prefer_single_quotes` rule
-
 # Additional information about this file can be found at
 # https://dart.dev/guides/language/analysis-options

--- a/packages/spikes/fcp_client/example/lib/main.dart
+++ b/packages/spikes/fcp_client/example/lib/main.dart
@@ -1,4 +1,4 @@
-// Copyright 2025 The Flutter Authors. All rights reserved.
+// Copyright 2025 The Flutter Authors.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/packages/spikes/fcp_client/example/lib/src/catalog/filter_chip_group.dart
+++ b/packages/spikes/fcp_client/example/lib/src/catalog/filter_chip_group.dart
@@ -1,4 +1,4 @@
-// Copyright 2025 The Flutter Authors. All rights reserved.
+// Copyright 2025 The Flutter Authors.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/packages/spikes/fcp_client/example/lib/src/catalog/itinerary_item.dart
+++ b/packages/spikes/fcp_client/example/lib/src/catalog/itinerary_item.dart
@@ -1,4 +1,4 @@
-// Copyright 2025 The Flutter Authors. All rights reserved.
+// Copyright 2025 The Flutter Authors.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/packages/spikes/fcp_client/example/lib/src/catalog/itinerary_with_details.dart
+++ b/packages/spikes/fcp_client/example/lib/src/catalog/itinerary_with_details.dart
@@ -1,4 +1,4 @@
-// Copyright 2025 The Flutter Authors. All rights reserved.
+// Copyright 2025 The Flutter Authors.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/packages/spikes/fcp_client/example/lib/src/catalog/options_filter_chip.dart
+++ b/packages/spikes/fcp_client/example/lib/src/catalog/options_filter_chip.dart
@@ -1,4 +1,4 @@
-// Copyright 2025 The Flutter Authors. All rights reserved.
+// Copyright 2025 The Flutter Authors.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/packages/spikes/fcp_client/example/lib/src/catalog/tabbed_sections.dart
+++ b/packages/spikes/fcp_client/example/lib/src/catalog/tabbed_sections.dart
@@ -1,4 +1,4 @@
-// Copyright 2025 The Flutter Authors. All rights reserved.
+// Copyright 2025 The Flutter Authors.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/packages/spikes/fcp_client/example/lib/src/catalog/travel_carousel.dart
+++ b/packages/spikes/fcp_client/example/lib/src/catalog/travel_carousel.dart
@@ -1,4 +1,4 @@
-// Copyright 2025 The Flutter Authors. All rights reserved.
+// Copyright 2025 The Flutter Authors.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/packages/spikes/fcp_client/example/lib/src/fcp_registry.dart
+++ b/packages/spikes/fcp_client/example/lib/src/fcp_registry.dart
@@ -1,4 +1,4 @@
-// Copyright 2025 The Flutter Authors. All rights reserved.
+// Copyright 2025 The Flutter Authors.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/packages/spikes/fcp_client/example/lib/src/widgets/fcp_column.dart
+++ b/packages/spikes/fcp_client/example/lib/src/widgets/fcp_column.dart
@@ -1,4 +1,4 @@
-// Copyright 2025 The Flutter Authors. All rights reserved.
+// Copyright 2025 The Flutter Authors.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/packages/spikes/fcp_client/example/lib/src/widgets/fcp_container.dart
+++ b/packages/spikes/fcp_client/example/lib/src/widgets/fcp_container.dart
@@ -1,4 +1,4 @@
-// Copyright 2025 The Flutter Authors. All rights reserved.
+// Copyright 2025 The Flutter Authors.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/packages/spikes/fcp_client/example/lib/src/widgets/fcp_elevated_button.dart
+++ b/packages/spikes/fcp_client/example/lib/src/widgets/fcp_elevated_button.dart
@@ -1,4 +1,4 @@
-// Copyright 2025 The Flutter Authors. All rights reserved.
+// Copyright 2025 The Flutter Authors.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/packages/spikes/fcp_client/example/lib/src/widgets/fcp_icon.dart
+++ b/packages/spikes/fcp_client/example/lib/src/widgets/fcp_icon.dart
@@ -1,4 +1,4 @@
-// Copyright 2025 The Flutter Authors. All rights reserved.
+// Copyright 2025 The Flutter Authors.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/packages/spikes/fcp_client/example/lib/src/widgets/fcp_row.dart
+++ b/packages/spikes/fcp_client/example/lib/src/widgets/fcp_row.dart
@@ -1,4 +1,4 @@
-// Copyright 2025 The Flutter Authors. All rights reserved.
+// Copyright 2025 The Flutter Authors.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/packages/spikes/fcp_client/example/lib/src/widgets/widgets.dart
+++ b/packages/spikes/fcp_client/example/lib/src/widgets/widgets.dart
@@ -1,4 +1,4 @@
-// Copyright 2025 The Flutter Authors. All rights reserved.
+// Copyright 2025 The Flutter Authors.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/packages/spikes/fcp_client/example/linux/CMakeLists.txt
+++ b/packages/spikes/fcp_client/example/linux/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2025 The Flutter Authors. All rights reserved.
+# Copyright 2025 The Flutter Authors.
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 

--- a/packages/spikes/fcp_client/example/linux/flutter/CMakeLists.txt
+++ b/packages/spikes/fcp_client/example/linux/flutter/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2025 The Flutter Authors. All rights reserved.
+# Copyright 2025 The Flutter Authors.
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 

--- a/packages/spikes/fcp_client/example/linux/runner/CMakeLists.txt
+++ b/packages/spikes/fcp_client/example/linux/runner/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2025 The Flutter Authors. All rights reserved.
+# Copyright 2025 The Flutter Authors.
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 

--- a/packages/spikes/fcp_client/example/linux/runner/main.cc
+++ b/packages/spikes/fcp_client/example/linux/runner/main.cc
@@ -1,4 +1,4 @@
-// Copyright 2025 The Flutter Authors. All rights reserved.
+// Copyright 2025 The Flutter Authors.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/packages/spikes/fcp_client/example/linux/runner/my_application.cc
+++ b/packages/spikes/fcp_client/example/linux/runner/my_application.cc
@@ -1,4 +1,4 @@
-// Copyright 2025 The Flutter Authors. All rights reserved.
+// Copyright 2025 The Flutter Authors.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/packages/spikes/fcp_client/example/linux/runner/my_application.h
+++ b/packages/spikes/fcp_client/example/linux/runner/my_application.h
@@ -1,4 +1,4 @@
-// Copyright 2025 The Flutter Authors. All rights reserved.
+// Copyright 2025 The Flutter Authors.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/packages/spikes/fcp_client/example/macos/Runner/AppDelegate.swift
+++ b/packages/spikes/fcp_client/example/macos/Runner/AppDelegate.swift
@@ -1,4 +1,4 @@
-// Copyright 2025 The Flutter Authors. All rights reserved.
+// Copyright 2025 The Flutter Authors.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/packages/spikes/fcp_client/example/macos/Runner/Configs/AppInfo.xcconfig
+++ b/packages/spikes/fcp_client/example/macos/Runner/Configs/AppInfo.xcconfig
@@ -11,4 +11,4 @@ PRODUCT_NAME = example
 PRODUCT_BUNDLE_IDENTIFIER = com.example.example
 
 // The copyright displayed in application information
-PRODUCT_COPYRIGHT = Copyright © 2025 com.example. All rights reserved.
+PRODUCT_COPYRIGHT = Copyright © 2025 com.example.

--- a/packages/spikes/fcp_client/example/macos/Runner/MainFlutterWindow.swift
+++ b/packages/spikes/fcp_client/example/macos/Runner/MainFlutterWindow.swift
@@ -1,4 +1,4 @@
-// Copyright 2025 The Flutter Authors. All rights reserved.
+// Copyright 2025 The Flutter Authors.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/packages/spikes/fcp_client/example/macos/RunnerTests/RunnerTests.swift
+++ b/packages/spikes/fcp_client/example/macos/RunnerTests/RunnerTests.swift
@@ -1,4 +1,4 @@
-// Copyright 2025 The Flutter Authors. All rights reserved.
+// Copyright 2025 The Flutter Authors.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/packages/spikes/fcp_client/example/pubspec.yaml
+++ b/packages/spikes/fcp_client/example/pubspec.yaml
@@ -1,4 +1,4 @@
-# Copyright 2025 The Flutter Authors. All rights reserved.
+# Copyright 2025 The Flutter Authors.
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 

--- a/packages/spikes/fcp_client/example/test_driver/app_test.dart
+++ b/packages/spikes/fcp_client/example/test_driver/app_test.dart
@@ -1,4 +1,4 @@
-// Copyright 2025 The Flutter Authors. All rights reserved.
+// Copyright 2025 The Flutter Authors.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/packages/spikes/fcp_client/example/test_driver/driver_main.dart
+++ b/packages/spikes/fcp_client/example/test_driver/driver_main.dart
@@ -1,4 +1,4 @@
-// Copyright 2025 The Flutter Authors. All rights reserved.
+// Copyright 2025 The Flutter Authors.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/packages/spikes/fcp_client/example/web/index.html
+++ b/packages/spikes/fcp_client/example/web/index.html
@@ -1,10 +1,10 @@
 <!DOCTYPE html>
-<!-- Copyright 2025 The Flutter Authors. All rights reserved.
+<!-- Copyright 2025 The Flutter Authors.
 Use of this source code is governed by a BSD-style license that can be
 found in the LICENSE file. -->
 <html>
-<head>
-  <!--
+  <head>
+    <!--
     If you are serving your web app in a path other than the root, change the
     href value below to reflect the base path you are serving from.
 
@@ -17,25 +17,25 @@ found in the LICENSE file. -->
     This is a placeholder for base href that will be replaced by the value of
     the `--base-href` argument provided to `flutter build`.
   -->
-  <base href="$FLUTTER_BASE_HREF">
+    <base href="$FLUTTER_BASE_HREF" />
 
-  <meta charset="UTF-8">
-  <meta content="IE=Edge" http-equiv="X-UA-Compatible">
-  <meta name="description" content="A new Flutter project.">
+    <meta charset="UTF-8" />
+    <meta content="IE=Edge" http-equiv="X-UA-Compatible" />
+    <meta name="description" content="A new Flutter project." />
 
-  <!-- iOS meta tags & icons -->
-  <meta name="mobile-web-app-capable" content="yes">
-  <meta name="apple-mobile-web-app-status-bar-style" content="black">
-  <meta name="apple-mobile-web-app-title" content="example">
-  <link rel="apple-touch-icon" href="icons/Icon-192.png">
+    <!-- iOS meta tags & icons -->
+    <meta name="mobile-web-app-capable" content="yes" />
+    <meta name="apple-mobile-web-app-status-bar-style" content="black" />
+    <meta name="apple-mobile-web-app-title" content="example" />
+    <link rel="apple-touch-icon" href="icons/Icon-192.png" />
 
-  <!-- Favicon -->
-  <link rel="icon" type="image/png" href="favicon.png"/>
+    <!-- Favicon -->
+    <link rel="icon" type="image/png" href="favicon.png" />
 
-  <title>example</title>
-  <link rel="manifest" href="manifest.json">
-</head>
-<body>
-  <script src="flutter_bootstrap.js" async></script>
-</body>
+    <title>example</title>
+    <link rel="manifest" href="manifest.json" />
+  </head>
+  <body>
+    <script src="flutter_bootstrap.js" async></script>
+  </body>
 </html>

--- a/packages/spikes/fcp_client/lib/fcp_client.dart
+++ b/packages/spikes/fcp_client/lib/fcp_client.dart
@@ -1,4 +1,4 @@
-// Copyright 2025 The Flutter Authors. All rights reserved.
+// Copyright 2025 The Flutter Authors.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/packages/spikes/fcp_client/lib/src/constants.dart
+++ b/packages/spikes/fcp_client/lib/src/constants.dart
@@ -1,4 +1,4 @@
-// Copyright 2025 The Flutter Authors. All rights reserved.
+// Copyright 2025 The Flutter Authors.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/packages/spikes/fcp_client/lib/src/core/binding_processor.dart
+++ b/packages/spikes/fcp_client/lib/src/core/binding_processor.dart
@@ -1,4 +1,4 @@
-// Copyright 2025 The Flutter Authors. All rights reserved.
+// Copyright 2025 The Flutter Authors.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/packages/spikes/fcp_client/lib/src/core/catalog_service.dart
+++ b/packages/spikes/fcp_client/lib/src/core/catalog_service.dart
@@ -1,4 +1,4 @@
-// Copyright 2025 The Flutter Authors. All rights reserved.
+// Copyright 2025 The Flutter Authors.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/packages/spikes/fcp_client/lib/src/core/data_type_validator.dart
+++ b/packages/spikes/fcp_client/lib/src/core/data_type_validator.dart
@@ -1,4 +1,4 @@
-// Copyright 2025 The Flutter Authors. All rights reserved.
+// Copyright 2025 The Flutter Authors.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/packages/spikes/fcp_client/lib/src/core/fcp_state.dart
+++ b/packages/spikes/fcp_client/lib/src/core/fcp_state.dart
@@ -1,4 +1,4 @@
-// Copyright 2025 The Flutter Authors. All rights reserved.
+// Copyright 2025 The Flutter Authors.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/packages/spikes/fcp_client/lib/src/core/layout_patcher.dart
+++ b/packages/spikes/fcp_client/lib/src/core/layout_patcher.dart
@@ -1,4 +1,4 @@
-// Copyright 2025 The Flutter Authors. All rights reserved.
+// Copyright 2025 The Flutter Authors.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/packages/spikes/fcp_client/lib/src/core/state_patcher.dart
+++ b/packages/spikes/fcp_client/lib/src/core/state_patcher.dart
@@ -1,4 +1,4 @@
-// Copyright 2025 The Flutter Authors. All rights reserved.
+// Copyright 2025 The Flutter Authors.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/packages/spikes/fcp_client/lib/src/core/widget_catalog_registry.dart
+++ b/packages/spikes/fcp_client/lib/src/core/widget_catalog_registry.dart
@@ -1,4 +1,4 @@
-// Copyright 2025 The Flutter Authors. All rights reserved.
+// Copyright 2025 The Flutter Authors.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/packages/spikes/fcp_client/lib/src/models/models.dart
+++ b/packages/spikes/fcp_client/lib/src/models/models.dart
@@ -1,4 +1,4 @@
-// Copyright 2025 The Flutter Authors. All rights reserved.
+// Copyright 2025 The Flutter Authors.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/packages/spikes/fcp_client/lib/src/widgets/fcp_provider.dart
+++ b/packages/spikes/fcp_client/lib/src/widgets/fcp_provider.dart
@@ -1,4 +1,4 @@
-// Copyright 2025 The Flutter Authors. All rights reserved.
+// Copyright 2025 The Flutter Authors.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/packages/spikes/fcp_client/lib/src/widgets/fcp_view.dart
+++ b/packages/spikes/fcp_client/lib/src/widgets/fcp_view.dart
@@ -1,4 +1,4 @@
-// Copyright 2025 The Flutter Authors. All rights reserved.
+// Copyright 2025 The Flutter Authors.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/packages/spikes/fcp_client/lib/src/widgets/fcp_view_controller.dart
+++ b/packages/spikes/fcp_client/lib/src/widgets/fcp_view_controller.dart
@@ -1,4 +1,4 @@
-// Copyright 2025 The Flutter Authors. All rights reserved.
+// Copyright 2025 The Flutter Authors.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/packages/spikes/fcp_client/pubspec.yaml
+++ b/packages/spikes/fcp_client/pubspec.yaml
@@ -1,4 +1,4 @@
-# Copyright 2025 The Flutter Authors. All rights reserved.
+# Copyright 2025 The Flutter Authors.
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 

--- a/packages/spikes/fcp_client/test/core/binding_processor_test.dart
+++ b/packages/spikes/fcp_client/test/core/binding_processor_test.dart
@@ -1,4 +1,4 @@
-// Copyright 2025 The Flutter Authors. All rights reserved.
+// Copyright 2025 The Flutter Authors.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/packages/spikes/fcp_client/test/core/catalog_service_test.dart
+++ b/packages/spikes/fcp_client/test/core/catalog_service_test.dart
@@ -1,4 +1,4 @@
-// Copyright 2025 The Flutter Authors. All rights reserved.
+// Copyright 2025 The Flutter Authors.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/packages/spikes/fcp_client/test/core/data_type_validator_test.dart
+++ b/packages/spikes/fcp_client/test/core/data_type_validator_test.dart
@@ -1,4 +1,4 @@
-// Copyright 2025 The Flutter Authors. All rights reserved.
+// Copyright 2025 The Flutter Authors.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/packages/spikes/fcp_client/test/core/fcp_state_test.dart
+++ b/packages/spikes/fcp_client/test/core/fcp_state_test.dart
@@ -1,4 +1,4 @@
-// Copyright 2025 The Flutter Authors. All rights reserved.
+// Copyright 2025 The Flutter Authors.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/packages/spikes/fcp_client/test/core/layout_patcher_test.dart
+++ b/packages/spikes/fcp_client/test/core/layout_patcher_test.dart
@@ -1,4 +1,4 @@
-// Copyright 2025 The Flutter Authors. All rights reserved.
+// Copyright 2025 The Flutter Authors.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/packages/spikes/fcp_client/test/core/state_patcher_test.dart
+++ b/packages/spikes/fcp_client/test/core/state_patcher_test.dart
@@ -1,4 +1,4 @@
-// Copyright 2025 The Flutter Authors. All rights reserved.
+// Copyright 2025 The Flutter Authors.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/packages/spikes/fcp_client/test/core/widget_registry_test.dart
+++ b/packages/spikes/fcp_client/test/core/widget_registry_test.dart
@@ -1,4 +1,4 @@
-// Copyright 2025 The Flutter Authors. All rights reserved.
+// Copyright 2025 The Flutter Authors.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/packages/spikes/fcp_client/test/models_test.dart
+++ b/packages/spikes/fcp_client/test/models_test.dart
@@ -1,4 +1,4 @@
-// Copyright 2025 The Flutter Authors. All rights reserved.
+// Copyright 2025 The Flutter Authors.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/packages/spikes/fcp_client/test/widgets/error_handling_test.dart
+++ b/packages/spikes/fcp_client/test/widgets/error_handling_test.dart
@@ -1,4 +1,4 @@
-// Copyright 2025 The Flutter Authors. All rights reserved.
+// Copyright 2025 The Flutter Authors.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/packages/spikes/fcp_client/test/widgets/fcp_view_test.dart
+++ b/packages/spikes/fcp_client/test/widgets/fcp_view_test.dart
@@ -1,4 +1,4 @@
-// Copyright 2025 The Flutter Authors. All rights reserved.
+// Copyright 2025 The Flutter Authors.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/packages/spikes/fcp_client/test/widgets/list_view_builder_test.dart
+++ b/packages/spikes/fcp_client/test/widgets/list_view_builder_test.dart
@@ -1,4 +1,4 @@
-// Copyright 2025 The Flutter Authors. All rights reserved.
+// Copyright 2025 The Flutter Authors.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/packages/spikes/fcp_client/test_fixtures/m1_integration/analysis_options.yaml
+++ b/packages/spikes/fcp_client/test_fixtures/m1_integration/analysis_options.yaml
@@ -1,4 +1,4 @@
-# Copyright 2025 The Flutter Authors. All rights reserved.
+# Copyright 2025 The Flutter Authors.
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 
@@ -27,6 +27,5 @@ linter:
   rules:
     # avoid_print: false  # Uncomment to disable the `avoid_print` rule
     # prefer_single_quotes: true  # Uncomment to enable the `prefer_single_quotes` rule
-
 # Additional information about this file can be found at
 # https://dart.dev/guides/language/analysis-options

--- a/packages/spikes/fcp_client/test_fixtures/m1_integration/integration_test/app_test.dart
+++ b/packages/spikes/fcp_client/test_fixtures/m1_integration/integration_test/app_test.dart
@@ -1,4 +1,4 @@
-// Copyright 2025 The Flutter Authors. All rights reserved.
+// Copyright 2025 The Flutter Authors.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/packages/spikes/fcp_client/test_fixtures/m1_integration/lib/main.dart
+++ b/packages/spikes/fcp_client/test_fixtures/m1_integration/lib/main.dart
@@ -1,4 +1,4 @@
-// Copyright 2025 The Flutter Authors. All rights reserved.
+// Copyright 2025 The Flutter Authors.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/packages/spikes/fcp_client/test_fixtures/m1_integration/linux/CMakeLists.txt
+++ b/packages/spikes/fcp_client/test_fixtures/m1_integration/linux/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2025 The Flutter Authors. All rights reserved.
+# Copyright 2025 The Flutter Authors.
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 

--- a/packages/spikes/fcp_client/test_fixtures/m1_integration/linux/flutter/CMakeLists.txt
+++ b/packages/spikes/fcp_client/test_fixtures/m1_integration/linux/flutter/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2025 The Flutter Authors. All rights reserved.
+# Copyright 2025 The Flutter Authors.
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 

--- a/packages/spikes/fcp_client/test_fixtures/m1_integration/linux/runner/CMakeLists.txt
+++ b/packages/spikes/fcp_client/test_fixtures/m1_integration/linux/runner/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2025 The Flutter Authors. All rights reserved.
+# Copyright 2025 The Flutter Authors.
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 

--- a/packages/spikes/fcp_client/test_fixtures/m1_integration/linux/runner/main.cc
+++ b/packages/spikes/fcp_client/test_fixtures/m1_integration/linux/runner/main.cc
@@ -1,4 +1,4 @@
-// Copyright 2025 The Flutter Authors. All rights reserved.
+// Copyright 2025 The Flutter Authors.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/packages/spikes/fcp_client/test_fixtures/m1_integration/linux/runner/my_application.cc
+++ b/packages/spikes/fcp_client/test_fixtures/m1_integration/linux/runner/my_application.cc
@@ -1,4 +1,4 @@
-// Copyright 2025 The Flutter Authors. All rights reserved.
+// Copyright 2025 The Flutter Authors.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/packages/spikes/fcp_client/test_fixtures/m1_integration/linux/runner/my_application.h
+++ b/packages/spikes/fcp_client/test_fixtures/m1_integration/linux/runner/my_application.h
@@ -1,4 +1,4 @@
-// Copyright 2025 The Flutter Authors. All rights reserved.
+// Copyright 2025 The Flutter Authors.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/packages/spikes/fcp_client/test_fixtures/m1_integration/macos/Runner/AppDelegate.swift
+++ b/packages/spikes/fcp_client/test_fixtures/m1_integration/macos/Runner/AppDelegate.swift
@@ -1,4 +1,4 @@
-// Copyright 2025 The Flutter Authors. All rights reserved.
+// Copyright 2025 The Flutter Authors.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/packages/spikes/fcp_client/test_fixtures/m1_integration/macos/Runner/Configs/AppInfo.xcconfig
+++ b/packages/spikes/fcp_client/test_fixtures/m1_integration/macos/Runner/Configs/AppInfo.xcconfig
@@ -11,4 +11,4 @@ PRODUCT_NAME = m1_integration
 PRODUCT_BUNDLE_IDENTIFIER = com.example.m1Integration
 
 // The copyright displayed in application information
-PRODUCT_COPYRIGHT = Copyright © 2025 com.example. All rights reserved.
+PRODUCT_COPYRIGHT = Copyright © 2025 com.example.

--- a/packages/spikes/fcp_client/test_fixtures/m1_integration/macos/Runner/MainFlutterWindow.swift
+++ b/packages/spikes/fcp_client/test_fixtures/m1_integration/macos/Runner/MainFlutterWindow.swift
@@ -1,4 +1,4 @@
-// Copyright 2025 The Flutter Authors. All rights reserved.
+// Copyright 2025 The Flutter Authors.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/packages/spikes/fcp_client/test_fixtures/m1_integration/macos/RunnerTests/RunnerTests.swift
+++ b/packages/spikes/fcp_client/test_fixtures/m1_integration/macos/RunnerTests/RunnerTests.swift
@@ -1,4 +1,4 @@
-// Copyright 2025 The Flutter Authors. All rights reserved.
+// Copyright 2025 The Flutter Authors.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/packages/spikes/fcp_client/test_fixtures/m1_integration/pubspec.yaml
+++ b/packages/spikes/fcp_client/test_fixtures/m1_integration/pubspec.yaml
@@ -1,4 +1,4 @@
-# Copyright 2025 The Flutter Authors. All rights reserved.
+# Copyright 2025 The Flutter Authors.
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 

--- a/packages/spikes/fcp_client/test_fixtures/m1_integration/web/index.html
+++ b/packages/spikes/fcp_client/test_fixtures/m1_integration/web/index.html
@@ -1,10 +1,10 @@
 <!DOCTYPE html>
-<!-- Copyright 2025 The Flutter Authors. All rights reserved.
+<!-- Copyright 2025 The Flutter Authors.
 Use of this source code is governed by a BSD-style license that can be
 found in the LICENSE file. -->
 <html>
-<head>
-  <!--
+  <head>
+    <!--
     If you are serving your web app in a path other than the root, change the
     href value below to reflect the base path you are serving from.
 
@@ -17,25 +17,25 @@ found in the LICENSE file. -->
     This is a placeholder for base href that will be replaced by the value of
     the `--base-href` argument provided to `flutter build`.
   -->
-  <base href="$FLUTTER_BASE_HREF">
+    <base href="$FLUTTER_BASE_HREF" />
 
-  <meta charset="UTF-8">
-  <meta content="IE=Edge" http-equiv="X-UA-Compatible">
-  <meta name="description" content="A new Flutter project.">
+    <meta charset="UTF-8" />
+    <meta content="IE=Edge" http-equiv="X-UA-Compatible" />
+    <meta name="description" content="A new Flutter project." />
 
-  <!-- iOS meta tags & icons -->
-  <meta name="mobile-web-app-capable" content="yes">
-  <meta name="apple-mobile-web-app-status-bar-style" content="black">
-  <meta name="apple-mobile-web-app-title" content="m1_integration">
-  <link rel="apple-touch-icon" href="icons/Icon-192.png">
+    <!-- iOS meta tags & icons -->
+    <meta name="mobile-web-app-capable" content="yes" />
+    <meta name="apple-mobile-web-app-status-bar-style" content="black" />
+    <meta name="apple-mobile-web-app-title" content="m1_integration" />
+    <link rel="apple-touch-icon" href="icons/Icon-192.png" />
 
-  <!-- Favicon -->
-  <link rel="icon" type="image/png" href="favicon.png"/>
+    <!-- Favicon -->
+    <link rel="icon" type="image/png" href="favicon.png" />
 
-  <title>m1_integration</title>
-  <link rel="manifest" href="manifest.json">
-</head>
-<body>
-  <script src="flutter_bootstrap.js" async></script>
-</body>
+    <title>m1_integration</title>
+    <link rel="manifest" href="manifest.json" />
+  </head>
+  <body>
+    <script src="flutter_bootstrap.js" async></script>
+  </body>
 </html>

--- a/packages/spikes/gulf_genkit_eval/genkit.conf.js
+++ b/packages/spikes/gulf_genkit_eval/genkit.conf.js
@@ -1,14 +1,12 @@
-// Copyright 2025 The Flutter Authors. All rights reserved.
+// Copyright 2025 The Flutter Authors.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import { googleAI } from '@genkit-ai/google-genai';
-import { configure } from 'genkit';
+import { googleAI } from "@genkit-ai/google-genai";
+import { configure } from "genkit";
 
 export default configure({
-  plugins: [
-    googleAI(),
-  ],
-  logLevel: 'debug',
+  plugins: [googleAI()],
+  logLevel: "debug",
   enableTracingAndMetrics: true,
 });

--- a/packages/spikes/gulf_genkit_eval/lib/index.js
+++ b/packages/spikes/gulf_genkit_eval/lib/index.js
@@ -1,41 +1,64 @@
-// Copyright 2025 The Flutter Authors. All rights reserved.
+// Copyright 2025 The Flutter Authors.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
 "use strict";
-var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
-    if (k2 === undefined) k2 = k;
-    var desc = Object.getOwnPropertyDescriptor(m, k);
-    if (!desc || ("get" in desc ? !m.__esModule : desc.writable || desc.configurable)) {
-      desc = { enumerable: true, get: function() { return m[k]; } };
-    }
-    Object.defineProperty(o, k2, desc);
-}) : (function(o, m, k, k2) {
-    if (k2 === undefined) k2 = k;
-    o[k2] = m[k];
-}));
-var __setModuleDefault = (this && this.__setModuleDefault) || (Object.create ? (function(o, v) {
-    Object.defineProperty(o, "default", { enumerable: true, value: v });
-}) : function(o, v) {
-    o["default"] = v;
-});
-var __importStar = (this && this.__importStar) || (function () {
-    var ownKeys = function(o) {
-        ownKeys = Object.getOwnPropertyNames || function (o) {
-            var ar = [];
-            for (var k in o) if (Object.prototype.hasOwnProperty.call(o, k)) ar[ar.length] = k;
-            return ar;
+var __createBinding =
+  (this && this.__createBinding) ||
+  (Object.create
+    ? function (o, m, k, k2) {
+        if (k2 === undefined) k2 = k;
+        var desc = Object.getOwnPropertyDescriptor(m, k);
+        if (
+          !desc ||
+          ("get" in desc ? !m.__esModule : desc.writable || desc.configurable)
+        ) {
+          desc = {
+            enumerable: true,
+            get: function () {
+              return m[k];
+            },
+          };
+        }
+        Object.defineProperty(o, k2, desc);
+      }
+    : function (o, m, k, k2) {
+        if (k2 === undefined) k2 = k;
+        o[k2] = m[k];
+      });
+var __setModuleDefault =
+  (this && this.__setModuleDefault) ||
+  (Object.create
+    ? function (o, v) {
+        Object.defineProperty(o, "default", { enumerable: true, value: v });
+      }
+    : function (o, v) {
+        o["default"] = v;
+      });
+var __importStar =
+  (this && this.__importStar) ||
+  (function () {
+    var ownKeys = function (o) {
+      ownKeys =
+        Object.getOwnPropertyNames ||
+        function (o) {
+          var ar = [];
+          for (var k in o)
+            if (Object.prototype.hasOwnProperty.call(o, k)) ar[ar.length] = k;
+          return ar;
         };
-        return ownKeys(o);
+      return ownKeys(o);
     };
     return function (mod) {
-        if (mod && mod.__esModule) return mod;
-        var result = {};
-        if (mod != null) for (var k = ownKeys(mod), i = 0; i < k.length; i++) if (k[i] !== "default") __createBinding(result, mod, k[i]);
-        __setModuleDefault(result, mod);
-        return result;
+      if (mod && mod.__esModule) return mod;
+      var result = {};
+      if (mod != null)
+        for (var k = ownKeys(mod), i = 0; i < k.length; i++)
+          if (k[i] !== "default") __createBinding(result, mod, k[i]);
+      __setModuleDefault(result, mod);
+      return result;
     };
-})();
+  })();
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.componentGeneratorFlow = void 0;
 const google_genai_1 = require("@genkit-ai/google-genai");
@@ -45,42 +68,56 @@ const path = __importStar(require("path"));
 const openai_1 = require("@genkit-ai/compat-oai/openai");
 const genkitx_anthropic_1 = require("genkitx-anthropic");
 // Read the schema file
-const schemaString = fs.readFileSync(path.join(__dirname, 'schema.json'), 'utf-8');
+const schemaString = fs.readFileSync(
+  path.join(__dirname, "schema.json"),
+  "utf-8"
+);
 const schema = JSON.parse(schemaString);
 const ai = (0, genkit_1.genkit)({
-    plugins: [(0, google_genai_1.googleAI)({ apiKey: process.env.GEMINI_API_KEY }), (0, openai_1.openAI)(), (0, genkitx_anthropic_1.anthropic)({ apiKey: process.env.ANTHROPIC_API_KEY }),],
+  plugins: [
+    (0, google_genai_1.googleAI)({ apiKey: process.env.GEMINI_API_KEY }),
+    (0, openai_1.openAI)(),
+    (0, genkitx_anthropic_1.anthropic)({
+      apiKey: process.env.ANTHROPIC_API_KEY,
+    }),
+  ],
 });
 // Define a UI component generator flow
-exports.componentGeneratorFlow = ai.defineFlow({
-    name: 'componentGeneratorFlow',
-    inputSchema: genkit_1.z.object({ prompt: genkit_1.z.string(), model: genkit_1.z.any() }),
+exports.componentGeneratorFlow = ai.defineFlow(
+  {
+    name: "componentGeneratorFlow",
+    inputSchema: genkit_1.z.object({
+      prompt: genkit_1.z.string(),
+      model: genkit_1.z.any(),
+    }),
     outputSchema: genkit_1.z.any(),
-}, async ({ prompt, model }) => {
+  },
+  async ({ prompt, model }) => {
     // Generate structured component data using the schema from the file
     const { output } = await ai.generate({
-        prompt,
-        model,
-        output: { jsonSchema: schema },
-        // config: {
-        //     thinkingConfig: { thinkingBudget: 0 }
-        // },
+      prompt,
+      model,
+      output: { jsonSchema: schema },
+      // config: {
+      //     thinkingConfig: { thinkingBudget: 0 }
+      // },
     });
-    if (!output)
-        throw new Error('Failed to generate component');
+    if (!output) throw new Error("Failed to generate component");
     return output;
-});
+  }
+);
 // Run the flow
 async function main() {
-    const models = [
-        openai_1.openAI.model('gpt-5-mini'),
-        openai_1.openAI.model('gpt-5'),
-        openai_1.openAI.model('gpt-5-nano'),
-        google_genai_1.googleAI.model('gemini-2.5-flash'),
-        google_genai_1.googleAI.model('gemini-2.5-flash-lite'),
-        genkitx_anthropic_1.claude4Sonnet,
-        genkitx_anthropic_1.claude35Haiku,
-    ];
-    const prompt = `Generate a JSON conforming to the schema to describe the following UI:
+  const models = [
+    openai_1.openAI.model("gpt-5-mini"),
+    openai_1.openAI.model("gpt-5"),
+    openai_1.openAI.model("gpt-5-nano"),
+    google_genai_1.googleAI.model("gemini-2.5-flash"),
+    google_genai_1.googleAI.model("gemini-2.5-flash-lite"),
+    genkitx_anthropic_1.claude4Sonnet,
+    genkitx_anthropic_1.claude35Haiku,
+  ];
+  const prompt = `Generate a JSON conforming to the schema to describe the following UI:
 
 A root node has already been created with ID "root". You need to create a ComponentUpdate message now.
 
@@ -100,13 +137,13 @@ The dog generator is another card which is a form that generates a fictional dog
 - A divider
 - A section which shows the generated content
 `;
-    for (const model of models) {
-        console.log(`Generating component with model: ${model.name}`);
-        const component = await (0, exports.componentGeneratorFlow)({
-            prompt,
-            model,
-        });
-        console.log(JSON.stringify(component, null, 2));
-    }
+  for (const model of models) {
+    console.log(`Generating component with model: ${model.name}`);
+    const component = await (0, exports.componentGeneratorFlow)({
+      prompt,
+      model,
+    });
+    console.log(JSON.stringify(component, null, 2));
+  }
 }
 main().catch(console.error);

--- a/packages/spikes/gulf_genkit_eval/src/index.ts
+++ b/packages/spikes/gulf_genkit_eval/src/index.ts
@@ -1,183 +1,211 @@
-// Copyright 2025 The Flutter Authors. All rights reserved.
+// Copyright 2025 The Flutter Authors.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import { googleAI } from '@genkit-ai/google-genai';
-import { genkit, z } from 'genkit';
-import * as fs from 'fs';
-import * as path from 'path';
-import { openAI } from '@genkit-ai/compat-oai/openai';
-import { anthropic } from 'genkitx-anthropic';
-import { modelsToTest } from './models';
-import { prompts, TestPrompt } from './prompts';
-import { validateSchema } from './validator';
+import { googleAI } from "@genkit-ai/google-genai";
+import { genkit, z } from "genkit";
+import * as fs from "fs";
+import * as path from "path";
+import { openAI } from "@genkit-ai/compat-oai/openai";
+import { anthropic } from "genkitx-anthropic";
+import { modelsToTest } from "./models";
+import { prompts, TestPrompt } from "./prompts";
+import { validateSchema } from "./validator";
 
 const ai = genkit({
-    plugins: [googleAI({ apiKey: process.env.GEMINI_API_KEY! }), openAI(), anthropic({ apiKey: process.env.ANTHROPIC_API_KEY }),
-    ],
+  plugins: [
+    googleAI({ apiKey: process.env.GEMINI_API_KEY! }),
+    openAI(),
+    anthropic({ apiKey: process.env.ANTHROPIC_API_KEY }),
+  ],
 });
 
 // Define a UI component generator flow
 export const componentGeneratorFlow = ai.defineFlow(
-    {
-        name: 'componentGeneratorFlow',
-        inputSchema: z.object({ prompt: z.string(), model: z.any(), config: z.any().optional(), schema: z.any() }),
-        outputSchema: z.any(),
-    },
-    async ({ prompt, model, config, schema }) => {
-        // Generate structured component data using the schema from the file
-        const { output } = await ai.generate({
-            prompt,
-            model,
-            output: { jsonSchema: schema },
-            config,
-        });
+  {
+    name: "componentGeneratorFlow",
+    inputSchema: z.object({
+      prompt: z.string(),
+      model: z.any(),
+      config: z.any().optional(),
+      schema: z.any(),
+    }),
+    outputSchema: z.any(),
+  },
+  async ({ prompt, model, config, schema }) => {
+    // Generate structured component data using the schema from the file
+    const { output } = await ai.generate({
+      prompt,
+      model,
+      output: { jsonSchema: schema },
+      config,
+    });
 
-        if (!output) throw new Error('Failed to generate component');
+    if (!output) throw new Error("Failed to generate component");
 
-        return output;
-    },
+    return output;
+  }
 );
 
 interface InferenceResult {
-    modelName: string;
-    prompt: TestPrompt;
-    component: any;
-    error: any;
-    latency: number;
-    validationResults: string[];
+  modelName: string;
+  prompt: TestPrompt;
+  component: any;
+  error: any;
+  latency: number;
+  validationResults: string[];
 }
 
 // Run the flow
 async function main() {
-    const args = process.argv.slice(2).reduce((acc, arg) => {
-        const [key, value] = arg.split('=');
-        if (key.startsWith('--')) {
-            if (value) {
-                acc[key.substring(2)] = value;
-            } else {
-                acc[key.substring(2)] = true;
-            }
-        }
-        return acc;
-    }, {} as Record<string, string | boolean>);
-
-    const verbose = !!args.verbose;
-
-    let filteredModels = modelsToTest;
-    if (typeof args.model === 'string') {
-        filteredModels = modelsToTest.filter(m => m.name === args.model);
-        if (filteredModels.length === 0) {
-            console.error(`Model "${args.model}" not found.`);
-            process.exit(1);
-        }
+  const args = process.argv.slice(2).reduce((acc, arg) => {
+    const [key, value] = arg.split("=");
+    if (key.startsWith("--")) {
+      if (value) {
+        acc[key.substring(2)] = value;
+      } else {
+        acc[key.substring(2)] = true;
+      }
     }
+    return acc;
+  }, {} as Record<string, string | boolean>);
 
-    let filteredPrompts = prompts;
-    if (typeof args.prompt === 'string') {
-        filteredPrompts = prompts.filter(p => p.name === args.prompt);
-        if (filteredPrompts.length === 0) {
-            console.error(`Prompt "${args.prompt}" not found.`);
-            process.exit(1);
-        }
+  const verbose = !!args.verbose;
+
+  let filteredModels = modelsToTest;
+  if (typeof args.model === "string") {
+    filteredModels = modelsToTest.filter((m) => m.name === args.model);
+    if (filteredModels.length === 0) {
+      console.error(`Model "${args.model}" not found.`);
+      process.exit(1);
     }
+  }
 
-    const generationPromises: Promise<InferenceResult>[] = [];
-
-    for (const prompt of filteredPrompts) {
-        const schemaString = fs.readFileSync(path.join(__dirname, prompt.schema), 'utf-8');
-        const schema = JSON.parse(schemaString);
-        for (const modelConfig of filteredModels) {
-            console.log(`Queueing generation for model: ${modelConfig.name}, prompt: ${prompt.name}`);
-            const startTime = Date.now();
-            generationPromises.push(
-                componentGeneratorFlow({
-                    prompt: prompt.promptText,
-                    model: modelConfig.model,
-                    config: modelConfig.config,
-                    schema,
-                }).then(component => {
-                    const validationResults = validateSchema(component, prompt.schema);
-                    return {
-                        modelName: modelConfig.name,
-                        prompt,
-                        component,
-                        error: null,
-                        latency: Date.now() - startTime,
-                        validationResults,
-                    };
-                }).catch(error => ({
-                    modelName: modelConfig.name,
-                    prompt,
-                    component: null,
-                    error,
-                    latency: Date.now() - startTime,
-                    validationResults: [],
-                }))
-            );
-        }
+  let filteredPrompts = prompts;
+  if (typeof args.prompt === "string") {
+    filteredPrompts = prompts.filter((p) => p.name === args.prompt);
+    if (filteredPrompts.length === 0) {
+      console.error(`Prompt "${args.prompt}" not found.`);
+      process.exit(1);
     }
+  }
 
-    const results = await Promise.all(generationPromises);
+  const generationPromises: Promise<InferenceResult>[] = [];
 
-    const resultsByModel: Record<string, InferenceResult[]> = {};
-
-    for (const result of results) {
-        if (!resultsByModel[result.modelName]) {
-            resultsByModel[result.modelName] = [];
-        }
-        resultsByModel[result.modelName].push(result);
+  for (const prompt of filteredPrompts) {
+    const schemaString = fs.readFileSync(
+      path.join(__dirname, prompt.schema),
+      "utf-8"
+    );
+    const schema = JSON.parse(schemaString);
+    for (const modelConfig of filteredModels) {
+      console.log(
+        `Queueing generation for model: ${modelConfig.name}, prompt: ${prompt.name}`
+      );
+      const startTime = Date.now();
+      generationPromises.push(
+        componentGeneratorFlow({
+          prompt: prompt.promptText,
+          model: modelConfig.model,
+          config: modelConfig.config,
+          schema,
+        })
+          .then((component) => {
+            const validationResults = validateSchema(component, prompt.schema);
+            return {
+              modelName: modelConfig.name,
+              prompt,
+              component,
+              error: null,
+              latency: Date.now() - startTime,
+              validationResults,
+            };
+          })
+          .catch((error) => ({
+            modelName: modelConfig.name,
+            prompt,
+            component: null,
+            error,
+            latency: Date.now() - startTime,
+            validationResults: [],
+          }))
+      );
     }
+  }
 
-    console.log('\n--- Generation Results ---');
-    for (const modelName in resultsByModel) {
-        console.log(`\n----------------------------------------`);
-        console.log(`Model: ${modelName}`);
-        console.log(`----------------------------------------`);
-        for (const result of resultsByModel[modelName]) {
-            console.log(`\nQuery: ${result.prompt.name}`);
-            console.log(`Latency: ${result.latency}ms`);
-            if (result.component) {
-                const hasValidationFailures = result.validationResults.length > 0;
-                if (hasValidationFailures) {
-                    console.log('Validation Failures:');
-                    result.validationResults.forEach(failure => console.log(`- ${failure}`));
-                    console.log('Generated schema:');
-                    console.log(JSON.stringify(result.component, null, 2));
-                } else if (verbose) {
-                    console.log(JSON.stringify(result.component, null, 2));
-                }
-            } else {
-                console.error('Error generating component:', result.error);
-            }
-        }
-    }
+  const results = await Promise.all(generationPromises);
 
-    console.log('\n--- Summary ---');
-    console.log('Model'.padEnd(40), 'Prompt Name'.padEnd(30), 'Latency (ms)'.padEnd(15), 'Val Failure Count'.padEnd(20), 'Status');
-    console.log('-'.repeat(115));
-    let totalFailures = 0;
-    let totalValidationErrors = 0;
-    for (const result of results) {
-        if (result.error) {
-            totalFailures++;
-        }
-        totalValidationErrors += result.validationResults?.length || 0;
-        const modelName = result.modelName.padEnd(40);
-        const promptName = result.prompt.name.padEnd(30);
-        const latency = (result.latency + 'ms').padEnd(15);
-        const valFailureCount = (result.validationResults?.length || 0).toString().padEnd(20);
-        const status = result.error ? 'FAILED' : 'PASSED';
-        console.log(`${modelName}${promptName}${latency}${valFailureCount}${status}`);
+  const resultsByModel: Record<string, InferenceResult[]> = {};
+
+  for (const result of results) {
+    if (!resultsByModel[result.modelName]) {
+      resultsByModel[result.modelName] = [];
     }
-    console.log('-'.repeat(115));
-    const totalsLabel = 'Totals:'.padEnd(40);
-    const emptyPrompt = ''.padEnd(30);
-    const emptyLatency = ''.padEnd(15);
-    const totalValidationErrorsStr = totalValidationErrors.toString().padEnd(20);
-    const totalFailuresStr = `${totalFailures} failures`;
-    console.log(`${totalsLabel}${emptyPrompt}${emptyLatency}${totalValidationErrorsStr}${totalFailuresStr}`);
+    resultsByModel[result.modelName].push(result);
+  }
+
+  console.log("\n--- Generation Results ---");
+  for (const modelName in resultsByModel) {
+    console.log(`\n----------------------------------------`);
+    console.log(`Model: ${modelName}`);
+    console.log(`----------------------------------------`);
+    for (const result of resultsByModel[modelName]) {
+      console.log(`\nQuery: ${result.prompt.name}`);
+      console.log(`Latency: ${result.latency}ms`);
+      if (result.component) {
+        const hasValidationFailures = result.validationResults.length > 0;
+        if (hasValidationFailures) {
+          console.log("Validation Failures:");
+          result.validationResults.forEach((failure) =>
+            console.log(`- ${failure}`)
+          );
+          console.log("Generated schema:");
+          console.log(JSON.stringify(result.component, null, 2));
+        } else if (verbose) {
+          console.log(JSON.stringify(result.component, null, 2));
+        }
+      } else {
+        console.error("Error generating component:", result.error);
+      }
+    }
+  }
+
+  console.log("\n--- Summary ---");
+  console.log(
+    "Model".padEnd(40),
+    "Prompt Name".padEnd(30),
+    "Latency (ms)".padEnd(15),
+    "Val Failure Count".padEnd(20),
+    "Status"
+  );
+  console.log("-".repeat(115));
+  let totalFailures = 0;
+  let totalValidationErrors = 0;
+  for (const result of results) {
+    if (result.error) {
+      totalFailures++;
+    }
+    totalValidationErrors += result.validationResults?.length || 0;
+    const modelName = result.modelName.padEnd(40);
+    const promptName = result.prompt.name.padEnd(30);
+    const latency = (result.latency + "ms").padEnd(15);
+    const valFailureCount = (result.validationResults?.length || 0)
+      .toString()
+      .padEnd(20);
+    const status = result.error ? "FAILED" : "PASSED";
+    console.log(
+      `${modelName}${promptName}${latency}${valFailureCount}${status}`
+    );
+  }
+  console.log("-".repeat(115));
+  const totalsLabel = "Totals:".padEnd(40);
+  const emptyPrompt = "".padEnd(30);
+  const emptyLatency = "".padEnd(15);
+  const totalValidationErrorsStr = totalValidationErrors.toString().padEnd(20);
+  const totalFailuresStr = `${totalFailures} failures`;
+  console.log(
+    `${totalsLabel}${emptyPrompt}${emptyLatency}${totalValidationErrorsStr}${totalFailuresStr}`
+  );
 }
-
 
 main().catch(console.error);

--- a/packages/spikes/gulf_genkit_eval/src/models.ts
+++ b/packages/spikes/gulf_genkit_eval/src/models.ts
@@ -1,51 +1,51 @@
-// Copyright 2025 The Flutter Authors. All rights reserved.
+// Copyright 2025 The Flutter Authors.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import { googleAI } from '@genkit-ai/google-genai';
-import { openAI } from '@genkit-ai/compat-oai/openai';
-import { claude35Haiku, claude4Sonnet } from 'genkitx-anthropic';
+import { googleAI } from "@genkit-ai/google-genai";
+import { openAI } from "@genkit-ai/compat-oai/openai";
+import { claude35Haiku, claude4Sonnet } from "genkitx-anthropic";
 
 export interface ModelConfiguration {
-    model: any;
-    name: string;
-    config?: any;
+  model: any;
+  name: string;
+  config?: any;
 }
 
 export const modelsToTest: ModelConfiguration[] = [
-    {
-        model: openAI.model('gpt-5'),
-        name: 'gpt-5 (reasoning: minimal)',
-        config: { reasoning_effort: 'minimal' },
-    },
-    {
-        model: openAI.model('gpt-5-mini'),
-        name: 'gpt-5-mini (reasoning: minimal)',
-        config: { reasoning_effort: 'minimal' },
-    },
-    {
-        model: openAI.model('gpt-5-nano'),
-        name: 'gpt-5-nano (reasoning: minimal)',
-        config: { reasoning_effort: 'minimal' },
-    },
-    {
-        model: googleAI.model('gemini-2.5-flash'),
-        name: 'gemini-2.5-flash (thinking: 0)',
-        config: { thinkingConfig: { thinkingBudget: 0 } },
-    },
-    {
-        model: googleAI.model('gemini-2.5-flash-lite'),
-        name: 'gemini-2.5-flash-lite (thinking: 0)',
-        config: { thinkingConfig: { thinkingBudget: 0 } },
-    },
-    {
-        model: claude4Sonnet,
-        name: 'claude-3-sonnet-20240229',
-        config: {},
-    },
-    {
-        model: claude35Haiku,
-        name: 'claude-3-haiku-20240307',
-        config: {},
-    },
+  {
+    model: openAI.model("gpt-5"),
+    name: "gpt-5 (reasoning: minimal)",
+    config: { reasoning_effort: "minimal" },
+  },
+  {
+    model: openAI.model("gpt-5-mini"),
+    name: "gpt-5-mini (reasoning: minimal)",
+    config: { reasoning_effort: "minimal" },
+  },
+  {
+    model: openAI.model("gpt-5-nano"),
+    name: "gpt-5-nano (reasoning: minimal)",
+    config: { reasoning_effort: "minimal" },
+  },
+  {
+    model: googleAI.model("gemini-2.5-flash"),
+    name: "gemini-2.5-flash (thinking: 0)",
+    config: { thinkingConfig: { thinkingBudget: 0 } },
+  },
+  {
+    model: googleAI.model("gemini-2.5-flash-lite"),
+    name: "gemini-2.5-flash-lite (thinking: 0)",
+    config: { thinkingConfig: { thinkingBudget: 0 } },
+  },
+  {
+    model: claude4Sonnet,
+    name: "claude-3-sonnet-20240229",
+    config: {},
+  },
+  {
+    model: claude35Haiku,
+    name: "claude-3-haiku-20240307",
+    config: {},
+  },
 ];

--- a/packages/spikes/gulf_genkit_eval/src/prompts.ts
+++ b/packages/spikes/gulf_genkit_eval/src/prompts.ts
@@ -1,20 +1,21 @@
-// Copyright 2025 The Flutter Authors. All rights reserved.
+// Copyright 2025 The Flutter Authors.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
 export interface TestPrompt {
-    promptText: string;
-    description: string;
-    name: string;
-    schema: string;
+  promptText: string;
+  description: string;
+  name: string;
+  schema: string;
 }
 
 export const prompts: TestPrompt[] = [
-    {
-        name: 'dogBreedGenerator',
-        description: 'A prompt to generate a UI for a dog breed information and generator tool.',
-        schema: 'component_update.json',
-        promptText: `Generate a JSON conforming to the schema to describe the following UI:
+  {
+    name: "dogBreedGenerator",
+    description:
+      "A prompt to generate a UI for a dog breed information and generator tool.",
+    schema: "component_update.json",
+    promptText: `Generate a JSON conforming to the schema to describe the following UI:
 
 A root node has already been created with ID "root". You need to create a ComponentUpdate message now.
 
@@ -34,41 +35,42 @@ The dog generator is another card which is a form that generates a fictional dog
 - A divider
 - A section which shows the generated content
 `,
-    },
-    {
-        name: 'loginForm',
-        description: 'A simple login form with username, password, a "remember me" checkbox, and a submit button.',
-        schema: 'component_update.json',
-        promptText: `Generate a JSON ComponentUpdate message for a login form. It should have a "Login" heading, two text fields for username and password (bound to /login/username and /login/password), a checkbox for "Remember Me" (bound to /login/rememberMe), and a "Sign In" button. The button should trigger a 'login' action, passing the username, password, and rememberMe status in the dynamicContext.`
-    },
-    {
-        name: 'productGallery',
-        description: 'A gallery of products using a list with a template.',
-        schema: 'component_update.json',
-        promptText: `Generate a JSON ComponentUpdate message for a product gallery. It should display a list of products from the data model at '/products'. Use a template for the list items. Each item should be a Card containing an Image (from '/products/item/imageUrl'), a Text component for the product name (from '/products/item/name'), and a Button labeled "Add to Cart". The button's action should be 'addToCart' and include a staticContext with the product ID, for example, 'productId': 'product123'. You should create a template component and then a list that uses it.`
-    },
-    {
-        name: 'settingsPage',
-        description: 'A settings page with tabs and a modal dialog.',
-        schema: 'component_update.json',
-        promptText: `Generate a JSON ComponentUpdate message for a user settings page. Use a Tabs component with two tabs: "Profile" and "Notifications". The "Profile" tab should contain a simple column with a text field for the user's name. The "Notifications" tab should contain a checkbox for "Enable email notifications". Also, include a Modal component. The modal's entry point should be a button labeled "Delete Account", and its content should be a column with a confirmation text and two buttons: "Confirm Deletion" and "Cancel".`
-    },
-    {
-        name: 'streamHeader',
-        description: 'A StreamHeader message to initialize the UI stream.',
-        schema: 'stream_header.json',
-        promptText: `Generate a JSON StreamHeader message. This is the very first message in a UI stream, used to establish the protocol version. The version should be "1.0.0".`
-    },
-    {
-        name: 'dataModelUpdate',
-        description: 'A DataModelUpdate message to update user data.',
-        schema: 'data_model_update.json',
-        promptText: `Generate a JSON DataModelUpdate message. This is used to update the client's data model. The scenario is that a user has just logged in, and we need to populate their profile information. Create data nodes to set '/user/name' to "John Doe" and '/user/email' to "john.doe@example.com".`
-    },
-    {
-        name: 'uiRoot',
-        description: 'A UIRoot message to set the initial UI and data roots.',
-        schema: 'begin_rendering.json',
-        promptText: `Generate a JSON UIRoot message. This message tells the client where to start rendering the UI and where the root of the data model is. Set the UI root to a component with ID "mainLayout" and the data model root to a node with ID "dataRoot".`
-    }
-]
+  },
+  {
+    name: "loginForm",
+    description:
+      'A simple login form with username, password, a "remember me" checkbox, and a submit button.',
+    schema: "component_update.json",
+    promptText: `Generate a JSON ComponentUpdate message for a login form. It should have a "Login" heading, two text fields for username and password (bound to /login/username and /login/password), a checkbox for "Remember Me" (bound to /login/rememberMe), and a "Sign In" button. The button should trigger a 'login' action, passing the username, password, and rememberMe status in the dynamicContext.`,
+  },
+  {
+    name: "productGallery",
+    description: "A gallery of products using a list with a template.",
+    schema: "component_update.json",
+    promptText: `Generate a JSON ComponentUpdate message for a product gallery. It should display a list of products from the data model at '/products'. Use a template for the list items. Each item should be a Card containing an Image (from '/products/item/imageUrl'), a Text component for the product name (from '/products/item/name'), and a Button labeled "Add to Cart". The button's action should be 'addToCart' and include a staticContext with the product ID, for example, 'productId': 'product123'. You should create a template component and then a list that uses it.`,
+  },
+  {
+    name: "settingsPage",
+    description: "A settings page with tabs and a modal dialog.",
+    schema: "component_update.json",
+    promptText: `Generate a JSON ComponentUpdate message for a user settings page. Use a Tabs component with two tabs: "Profile" and "Notifications". The "Profile" tab should contain a simple column with a text field for the user's name. The "Notifications" tab should contain a checkbox for "Enable email notifications". Also, include a Modal component. The modal's entry point should be a button labeled "Delete Account", and its content should be a column with a confirmation text and two buttons: "Confirm Deletion" and "Cancel".`,
+  },
+  {
+    name: "streamHeader",
+    description: "A StreamHeader message to initialize the UI stream.",
+    schema: "stream_header.json",
+    promptText: `Generate a JSON StreamHeader message. This is the very first message in a UI stream, used to establish the protocol version. The version should be "1.0.0".`,
+  },
+  {
+    name: "dataModelUpdate",
+    description: "A DataModelUpdate message to update user data.",
+    schema: "data_model_update.json",
+    promptText: `Generate a JSON DataModelUpdate message. This is used to update the client's data model. The scenario is that a user has just logged in, and we need to populate their profile information. Create data nodes to set '/user/name' to "John Doe" and '/user/email' to "john.doe@example.com".`,
+  },
+  {
+    name: "uiRoot",
+    description: "A UIRoot message to set the initial UI and data roots.",
+    schema: "begin_rendering.json",
+    promptText: `Generate a JSON UIRoot message. This message tells the client where to start rendering the UI and where the root of the data model is. Set the UI root to a component with ID "mainLayout" and the data model root to a node with ID "dataRoot".`,
+  },
+];

--- a/packages/spikes/gulf_genkit_eval/src/validator.ts
+++ b/packages/spikes/gulf_genkit_eval/src/validator.ts
@@ -1,160 +1,174 @@
-// Copyright 2025 The Flutter Authors. All rights reserved.
+// Copyright 2025 The Flutter Authors.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
 export function validateSchema(data: any, schemaName: string): string[] {
-    const errors: string[] = [];
+  const errors: string[] = [];
 
-    switch (schemaName) {
-        case 'stream_header.json':
-            validateStreamHeader(data, errors);
-            break;
-        case 'component_update.json':
-            validateComponentUpdate(data, errors);
-            break;
-        case 'data_model_update.json':
-            validateDataModelUpdate(data, errors);
-            break;
-        case 'begin_rendering.json':
-            validateBeginRendering(data, errors);
-            break;
-        default:
-            errors.push(`Unknown schema for validation: ${schemaName}`);
-    }
+  switch (schemaName) {
+    case "stream_header.json":
+      validateStreamHeader(data, errors);
+      break;
+    case "component_update.json":
+      validateComponentUpdate(data, errors);
+      break;
+    case "data_model_update.json":
+      validateDataModelUpdate(data, errors);
+      break;
+    case "begin_rendering.json":
+      validateBeginRendering(data, errors);
+      break;
+    default:
+      errors.push(`Unknown schema for validation: ${schemaName}`);
+  }
 
-    return errors;
+  return errors;
 }
 
 function validateStreamHeader(data: any, errors: string[]) {
-    if (!data.version) {
-        errors.push("StreamHeader must have a 'version' property.");
+  if (!data.version) {
+    errors.push("StreamHeader must have a 'version' property.");
+  }
+  const allowed = ["version"];
+  for (const key in data) {
+    if (!allowed.includes(key)) {
+      errors.push(`StreamHeader has unexpected property: ${key}`);
     }
-    const allowed = ['version'];
-    for (const key in data) {
-        if (!allowed.includes(key)) {
-            errors.push(`StreamHeader has unexpected property: ${key}`);
-        }
-    }
+  }
 }
 
 function validateComponentUpdate(data: any, errors: string[]) {
-    if (!data.components || !Array.isArray(data.components)) {
-        errors.push("ComponentUpdate must have a 'components' array.");
-        return;
-    }
+  if (!data.components || !Array.isArray(data.components)) {
+    errors.push("ComponentUpdate must have a 'components' array.");
+    return;
+  }
 
-    const componentIds = new Set<string>();
-    for (const c of data.components) {
-        if (c.id) {
-            if (componentIds.has(c.id)) {
-                errors.push(`Duplicate component ID found: ${c.id}`);
-            }
-            componentIds.add(c.id);
-        }
+  const componentIds = new Set<string>();
+  for (const c of data.components) {
+    if (c.id) {
+      if (componentIds.has(c.id)) {
+        errors.push(`Duplicate component ID found: ${c.id}`);
+      }
+      componentIds.add(c.id);
     }
+  }
 
-    for (const component of data.components) {
-        validateComponent(component, componentIds, errors);
-    }
+  for (const component of data.components) {
+    validateComponent(component, componentIds, errors);
+  }
 }
 
 function validateDataModelUpdate(data: any, errors: string[]) {
-    if (data.contents === undefined) {
-        errors.push("DataModelUpdate must have a 'contents' property.");
-    }
+  if (data.contents === undefined) {
+    errors.push("DataModelUpdate must have a 'contents' property.");
+  }
 }
 
 function validateBeginRendering(data: any, errors: string[]) {
-    if (!data.root) {
-        errors.push("BeginRendering message must have a 'root' property.");
-    }
+  if (!data.root) {
+    errors.push("BeginRendering message must have a 'root' property.");
+  }
 }
 
-function validateComponent(component: any, allIds: Set<string>, errors: string[]) {
-    if (!component.id) {
-        errors.push(`Component is missing an 'id'.`);
-        return; // Can't validate further without an ID
-    }
-    if (!component.type) {
-        errors.push(`Component '${component.id}' is missing a 'type'.`);
-        return;
-    }
+function validateComponent(
+  component: any,
+  allIds: Set<string>,
+  errors: string[]
+) {
+  if (!component.id) {
+    errors.push(`Component is missing an 'id'.`);
+    return; // Can't validate further without an ID
+  }
+  if (!component.type) {
+    errors.push(`Component '${component.id}' is missing a 'type'.`);
+    return;
+  }
 
-    const checkRequired = (props: string[]) => {
-        for (const prop of props) {
-            if (component[prop] === undefined) {
-                errors.push(`Component '${component.id}' of type '${component.type}' is missing required property '${prop}'.`);
-            }
+  const checkRequired = (props: string[]) => {
+    for (const prop of props) {
+      if (component[prop] === undefined) {
+        errors.push(
+          `Component '${component.id}' of type '${component.type}' is missing required property '${prop}'.`
+        );
+      }
+    }
+  };
+
+  const checkRefs = (ids: (string | undefined)[]) => {
+    for (const id of ids) {
+      if (id && !allIds.has(id)) {
+        errors.push(
+          `Component '${component.id}' references non-existent component ID '${id}'.`
+        );
+      }
+    }
+  };
+
+  switch (component.type) {
+    case "Heading":
+    case "Text":
+    case "Image":
+    case "Video":
+    case "AudioPlayer":
+    case "TextField":
+    case "DateTimeInput":
+    case "MultipleChoice":
+    case "Slider":
+      checkRequired(["value"]);
+      break;
+    case "CheckBox":
+      checkRequired(["value", "label"]);
+      break;
+    case "Row":
+    case "Column":
+    case "List":
+      checkRequired(["children"]);
+      if (component.children) {
+        const hasExplicit = !!component.children.explicitList;
+        const hasTemplate = !!component.children.template;
+        if ((hasExplicit && hasTemplate) || (!hasExplicit && !hasTemplate)) {
+          errors.push(
+            `Component '${component.id}' must have either 'explicitList' or 'template' in children, but not both or neither.`
+          );
         }
-    };
-
-    const checkRefs = (ids: (string | undefined)[]) => {
-        for (const id of ids) {
-            if (id && !allIds.has(id)) {
-                errors.push(`Component '${component.id}' references non-existent component ID '${id}'.`);
-            }
+        if (hasExplicit) {
+          checkRefs(component.children.explicitList);
         }
-    };
-
-    switch (component.type) {
-        case 'Heading':
-        case 'Text':
-        case 'Image':
-        case 'Video':
-        case 'AudioPlayer':
-        case 'TextField':
-        case 'DateTimeInput':
-        case 'MultipleChoice':
-        case 'Slider':
-            checkRequired(['value']);
-            break;
-        case 'CheckBox':
-            checkRequired(['value', 'label']);
-            break;
-        case 'Row':
-        case 'Column':
-        case 'List':
-            checkRequired(['children']);
-            if (component.children) {
-                const hasExplicit = !!component.children.explicitList;
-                const hasTemplate = !!component.children.template;
-                if ((hasExplicit && hasTemplate) || (!hasExplicit && !hasTemplate)) {
-                    errors.push(`Component '${component.id}' must have either 'explicitList' or 'template' in children, but not both or neither.`);
-                }
-                if (hasExplicit) {
-                    checkRefs(component.children.explicitList);
-                }
-                if (hasTemplate) {
-                    checkRefs([component.children.template?.componentId]);
-                }
-            }
-            break;
-        case 'Card':
-            checkRequired(['child']);
-            checkRefs([component.child]);
-            break;
-        case 'Tabs':
-            checkRequired(['tabItems']);
-            if (component.tabItems && Array.isArray(component.tabItems)) {
-                component.tabItems.forEach((tab: any) => {
-                    if (!tab.title) {
-                        errors.push(`Tab item in component '${component.id}' is missing a 'title'.`);
-                    }
-                    if (!tab.child) {
-                        errors.push(`Tab item in component '${component.id}' is missing a 'child'.`);
-                    }
-                    checkRefs([tab.child])
-                });
-            }
-            break;
-        case 'Modal':
-            checkRequired(['entryPointChild', 'contentChild']);
-            checkRefs([component.entryPointChild, component.contentChild]);
-            break;
-        case 'Button':
-            checkRequired(['label', 'action']);
-            break;
-        case 'Divider':
-            break;
-    }
+        if (hasTemplate) {
+          checkRefs([component.children.template?.componentId]);
+        }
+      }
+      break;
+    case "Card":
+      checkRequired(["child"]);
+      checkRefs([component.child]);
+      break;
+    case "Tabs":
+      checkRequired(["tabItems"]);
+      if (component.tabItems && Array.isArray(component.tabItems)) {
+        component.tabItems.forEach((tab: any) => {
+          if (!tab.title) {
+            errors.push(
+              `Tab item in component '${component.id}' is missing a 'title'.`
+            );
+          }
+          if (!tab.child) {
+            errors.push(
+              `Tab item in component '${component.id}' is missing a 'child'.`
+            );
+          }
+          checkRefs([tab.child]);
+        });
+      }
+      break;
+    case "Modal":
+      checkRequired(["entryPointChild", "contentChild"]);
+      checkRefs([component.entryPointChild, component.contentChild]);
+      break;
+    case "Button":
+      checkRequired(["label", "action"]);
+      break;
+    case "Divider":
+      break;
+  }
 }

--- a/tool/fix_copyright.sh
+++ b/tool/fix_copyright.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Copyright 2025 The Flutter Authors. All rights reserved.
+# Copyright 2025 The Flutter Authors.
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 

--- a/tool/fix_copyright/analysis_options.yaml
+++ b/tool/fix_copyright/analysis_options.yaml
@@ -1,6 +1,5 @@
-# Copyright 2025 The Flutter Authors. All rights reserved.
+# Copyright 2025 The Flutter Authors.
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 
 include: package:dart_flutter_team_lints/analysis_options.yaml
-

--- a/tool/fix_copyright/bin/fix_copyright.dart
+++ b/tool/fix_copyright/bin/fix_copyright.dart
@@ -1,4 +1,4 @@
-// Copyright 2025 The Flutter Authors. All rights reserved.
+// Copyright 2025 The Flutter Authors.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/tool/fix_copyright/lib/fix_copyright.dart
+++ b/tool/fix_copyright/lib/fix_copyright.dart
@@ -1,4 +1,4 @@
-// Copyright 2025 The Flutter Authors. All rights reserved.
+// Copyright 2025 The Flutter Authors.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/tool/fix_copyright/lib/src/fix_copyright.dart
+++ b/tool/fix_copyright/lib/src/fix_copyright.dart
@@ -1,4 +1,4 @@
-// Copyright 2025 The Flutter Authors. All rights reserved.
+// Copyright 2025 The Flutter Authors.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
@@ -183,7 +183,7 @@ Map<String, CopyrightInfo> _generateExtensionMap(String year) {
     String suffix = '',
     required bool isParagraph,
   }) {
-    return '''${prefix}Copyright $year The Flutter Authors. All rights reserved.${isParagraph ? '' : suffix}
+    return '''${prefix}Copyright $year The Flutter Authors.${isParagraph ? '' : suffix}
 ${isParagraph ? '' : prefix}Use of this source code is governed by a BSD-style license that can be${isParagraph ? '' : suffix}
 ${isParagraph ? '' : prefix}found in the LICENSE file.$suffix''';
   }
@@ -196,7 +196,7 @@ ${isParagraph ? '' : prefix}found in the LICENSE file.$suffix''';
     final escapedSuffix = RegExp.escape(suffix);
 
     return '($escapedPrefix'
-        r'Copyright (\d+) ([\w ]+)\.?\s+All rights reserved.'
+        r'Copyright (\d+) ([\w ]+)\.?(\s+All rights reserved.)?'
         '(?:$escapedSuffix)?\\n'
         '(?:$escapedPrefix)?'
         r'Use of this source code is governed by a [-\w]+ license that can be'

--- a/tool/fix_copyright/pubspec.yaml
+++ b/tool/fix_copyright/pubspec.yaml
@@ -1,4 +1,4 @@
-# Copyright 2025 The Flutter Authors. All rights reserved.
+# Copyright 2025 The Flutter Authors.
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 

--- a/tool/fix_copyright/test/fix_copyright_test.dart
+++ b/tool/fix_copyright/test/fix_copyright_test.dart
@@ -1,4 +1,4 @@
-// Copyright 2025 The Flutter Authors. All rights reserved.
+// Copyright 2025 The Flutter Authors.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
@@ -38,7 +38,7 @@ void main() {
     // Create test files
     fileSystem.file('compliant.dart').createSync();
     fileSystem.file('compliant.dart').writeAsStringSync('''
-// Copyright 2025 The Flutter Authors. All rights reserved.
+// Copyright 2025 The Flutter Authors.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
@@ -77,7 +77,7 @@ void main() {}
 
   test('--force updates non-compliant files', () async {
     final compliantContent = '''
-// Copyright 2025 The Flutter Authors. All rights reserved.
+// Copyright 2025 The Flutter Authors.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
@@ -92,7 +92,7 @@ void main() {}
     final incorrectYearFile = fileSystem.file('incorrect_year.dart')
       ..createSync()
       ..writeAsStringSync('''
-// Copyright 2020 The Flutter Authors. All rights reserved.
+// Copyright 2020 The Flutter Authors.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
@@ -124,7 +124,7 @@ void main() {}
       ..createSync()
       ..writeAsStringSync('''
 #!/bin/bash
-# Copyright 2020 The Flutter Authors. All rights reserved.
+# Copyright 2020 The Flutter Authors.
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 echo "Hello"
@@ -179,7 +179,7 @@ echo "Hello"
     fileSystem.file('compliant.dart')
       ..createSync()
       ..writeAsStringSync('''
-// Copyright 2025 The Flutter Authors. All rights reserved.
+// Copyright 2025 The Flutter Authors.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
@@ -218,7 +218,7 @@ void main() {}
       ..createSync()
       ..writeAsStringSync('''
 <!DOCTYPE html>
-<!-- Copyright 2025 The Flutter Authors. All rights reserved.
+<!-- Copyright 2025 The Flutter Authors.
 Use of this source code is governed by a BSD-style license that can be
 found in the LICENSE file. -->
 <html>

--- a/tool/refresh_firebase_template.sh
+++ b/tool/refresh_firebase_template.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Copyright 2025 The Flutter Authors. All rights reserved.
+# Copyright 2025 The Flutter Authors.
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 

--- a/tool/refresh_packages.sh
+++ b/tool/refresh_packages.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Copyright 2025 The Flutter Authors. All rights reserved.
+# Copyright 2025 The Flutter Authors.
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 

--- a/tool/run_all_tests_and_fixes.sh
+++ b/tool/run_all_tests_and_fixes.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Copyright 2025 The Flutter Authors. All rights reserved.
+# Copyright 2025 The Flutter Authors.
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 
@@ -46,7 +46,7 @@ run_project_step() {
     echo ""
     echo "### [$step_num/$PROJECT_TOTAL_STEPS] $description"
     echo "> To rerun this command:"
-    echo "> 
+    echo ">
 > (cd \"$project_dir\" && $cmd_str_for_display)
 > "
     if ! "${cmd_to_run[@]}"; then
@@ -87,7 +87,7 @@ echo "---"
 if [ -f "tool/fix_copyright/bin/fix_copyright.dart" ]; then
     echo "### Running copyright fix"
     echo "> To rerun this command:"
-    echo "> 
+    echo ">
 > dart run tool/fix_copyright/bin/fix_copyright.dart --force
 > "
     # Log failures without stopping the script.

--- a/tool/stub_firebase_options.sh
+++ b/tool/stub_firebase_options.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Copyright 2025 The Flutter Authors. All rights reserved.
+# Copyright 2025 The Flutter Authors.
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 


### PR DESCRIPTION
# Description

Removes "All rights reserved." from the license headers and updates the fix_copyright script to check for the right string.
