### PR TITLE
chore(simple_chat): fix instruction formatting

### DIFF
--- a/examples/simple_chat/lib/main.dart
+++ b/examples/simple_chat/lib/main.dart
@@ -48,16 +48,16 @@ class _ChatScreenState extends State<ChatScreen> {
   @override
   void initState() {
     super.initState();
-    const instruction = '''
-    You are a helpful assistant who chats with user,
-    giving exactly one response for each user message.
-    Your responses should contain acknowledgment
-    of the user message.
-    ''';
     final catalog = CoreCatalogItems.asCatalog();
     _genUiManager = GenUiManager(catalog: catalog);
     final aiClient = FirebaseAiClient(
-      systemInstruction: '$instruction\n\n${GenUiPromptFragments.basicChat}',
+      systemInstruction:
+          'You are a helpful assistant who chats with a user, '
+          'giving exactly one response for each user message. '
+          'Your responses should contain acknowledgment '
+          'of the user message.'
+          '\n\n'
+          '${GenUiPromptFragments.basicChat}',
       tools: _genUiManager.getTools(),
     );
     _uiAgent = UiAgent(


### PR DESCRIPTION
Fixes a grammatical typo in the prompt of the simple_chat example app. Also reformats part of the instruction as a single line, avoiding hard line wraps and indentations in the middle of sentences.

This might have negligible effect on LLM output, but I figure this is a very cheap improvement to make.

## Pre-launch Checklist

- [x] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [x] I signed the [CLA].
- [x] I read the [Contributors Guide].
- [ ] ~~I have added sample code updates to the [changelog].~~
- [ ] ~~I updated/added relevant documentation (doc comments with `///`).~~

<!-- Links -->

[Flutter Style Guide]: https://github.com/flutter/flutter/blob/master/docs/contributing/Style-guide-for-Flutter-repo.md
[CLA]: https://cla.developers.google.com/
[Discord]: https://github.com/flutter/flutter/blob/master/docs/contributing/Chat.md
[Contributors Guide]: https://github.com/flutter/samples/blob/main/CONTRIBUTING.md
[changelog]: ../CHANGELOG.md
