### PR TITLE
Fix reference. 

### DIFF
--- a/packages/flutter_genui/pubspec.yaml
+++ b/packages/flutter_genui/pubspec.yaml
@@ -18,6 +18,10 @@ dependencies:
   collection: ^1.19.1
   flutter:
     sdk: flutter
+
+  # Reference via path instead of git to allow local development, after
+  # the packages are published.
+  # See https://github.com/flutter/genui/pull/353.
   json_schema_builder:
     git:
       url: https://github.com/flutter/genui.git

--- a/packages/flutter_genui/pubspec.yaml
+++ b/packages/flutter_genui/pubspec.yaml
@@ -19,7 +19,9 @@ dependencies:
   flutter:
     sdk: flutter
   json_schema_builder:
-    path: ../json_schema_builder
+    git:
+      url: https://github.com/flutter/genui.git
+      path: packages/json_schema_builder
   logging: ^1.3.0
 
 dev_dependencies:


### PR DESCRIPTION
Currently if I want to build a catalog in my app, and reference both genui and json_schema_builder in git, I get this error:

```
Because ui_app depends on flutter_genui from git which depends on json_schema_builder
  from git, json_schema_builder from git https://github.com/flutter/genui.git at
  6501c398674a8b81f37f204d97f02ac0a407064b in packages/json_schema_builder is required.
So, because ui_app depends on json_schema_builder from git
  https://github.com/flutter/genui.git at HEAD in packages/json_schema_builder, version
  solving failed.
```



