### PR TITLE
fix(catalog): Correct catalog gallery display and layout

### DIFF
--- a/examples/catalog_gallery/.metadata
+++ b/examples/catalog_gallery/.metadata
@@ -4,8 +4,8 @@
 # This file should be version controlled and should not be manually edited.
 
 version:
-  revision: "b8962555571d8c170cff8e76023ea7bf60e5ec4b"
-  channel: "stable"
+  revision: "e20c5f5594a36affb23de6c49b9dbc4454b69b33"
+  channel: "main"
 
 project_type: app
 
@@ -13,26 +13,11 @@ project_type: app
 migration:
   platforms:
     - platform: root
-      create_revision: b8962555571d8c170cff8e76023ea7bf60e5ec4b
-      base_revision: b8962555571d8c170cff8e76023ea7bf60e5ec4b
-    - platform: android
-      create_revision: b8962555571d8c170cff8e76023ea7bf60e5ec4b
-      base_revision: b8962555571d8c170cff8e76023ea7bf60e5ec4b
-    - platform: ios
-      create_revision: b8962555571d8c170cff8e76023ea7bf60e5ec4b
-      base_revision: b8962555571d8c170cff8e76023ea7bf60e5ec4b
+      create_revision: e20c5f5594a36affb23de6c49b9dbc4454b69b33
+      base_revision: e20c5f5594a36affb23de6c49b9dbc4454b69b33
     - platform: linux
-      create_revision: b8962555571d8c170cff8e76023ea7bf60e5ec4b
-      base_revision: b8962555571d8c170cff8e76023ea7bf60e5ec4b
-    - platform: macos
-      create_revision: b8962555571d8c170cff8e76023ea7bf60e5ec4b
-      base_revision: b8962555571d8c170cff8e76023ea7bf60e5ec4b
-    - platform: web
-      create_revision: b8962555571d8c170cff8e76023ea7bf60e5ec4b
-      base_revision: b8962555571d8c170cff8e76023ea7bf60e5ec4b
-    - platform: windows
-      create_revision: b8962555571d8c170cff8e76023ea7bf60e5ec4b
-      base_revision: b8962555571d8c170cff8e76023ea7bf60e5ec4b
+      create_revision: e20c5f5594a36affb23de6c49b9dbc4454b69b33
+      base_revision: e20c5f5594a36affb23de6c49b9dbc4454b69b33
 
   # User provided section
 

--- a/examples/catalog_gallery/linux/.gitignore
+++ b/examples/catalog_gallery/linux/.gitignore
@@ -1,0 +1,1 @@
+flutter/ephemeral

--- a/examples/catalog_gallery/linux/CMakeLists.txt
+++ b/examples/catalog_gallery/linux/CMakeLists.txt
@@ -1,0 +1,128 @@
+# Project-level configuration.
+cmake_minimum_required(VERSION 3.13)
+project(runner LANGUAGES CXX)
+
+# The name of the executable created for the application. Change this to change
+# the on-disk name of your application.
+set(BINARY_NAME "catalog_gallery")
+# The unique GTK application identifier for this application. See:
+# https://wiki.gnome.org/HowDoI/ChooseApplicationID
+set(APPLICATION_ID "com.example.catalog_gallery")
+
+# Explicitly opt in to modern CMake behaviors to avoid warnings with recent
+# versions of CMake.
+cmake_policy(SET CMP0063 NEW)
+
+# Load bundled libraries from the lib/ directory relative to the binary.
+set(CMAKE_INSTALL_RPATH "$ORIGIN/lib")
+
+# Root filesystem for cross-building.
+if(FLUTTER_TARGET_PLATFORM_SYSROOT)
+  set(CMAKE_SYSROOT ${FLUTTER_TARGET_PLATFORM_SYSROOT})
+  set(CMAKE_FIND_ROOT_PATH ${CMAKE_SYSROOT})
+  set(CMAKE_FIND_ROOT_PATH_MODE_PROGRAM NEVER)
+  set(CMAKE_FIND_ROOT_PATH_MODE_PACKAGE ONLY)
+  set(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY ONLY)
+  set(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE ONLY)
+endif()
+
+# Define build configuration options.
+if(NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
+  set(CMAKE_BUILD_TYPE "Debug" CACHE
+    STRING "Flutter build mode" FORCE)
+  set_property(CACHE CMAKE_BUILD_TYPE PROPERTY STRINGS
+    "Debug" "Profile" "Release")
+endif()
+
+# Compilation settings that should be applied to most targets.
+#
+# Be cautious about adding new options here, as plugins use this function by
+# default. In most cases, you should add new options to specific targets instead
+# of modifying this function.
+function(APPLY_STANDARD_SETTINGS TARGET)
+  target_compile_features(${TARGET} PUBLIC cxx_std_14)
+  target_compile_options(${TARGET} PRIVATE -Wall -Werror)
+  target_compile_options(${TARGET} PRIVATE "$<$<NOT:$<CONFIG:Debug>>:-O3>")
+  target_compile_definitions(${TARGET} PRIVATE "$<$<NOT:$<CONFIG:Debug>>:NDEBUG>")
+endfunction()
+
+# Flutter library and tool build rules.
+set(FLUTTER_MANAGED_DIR "${CMAKE_CURRENT_SOURCE_DIR}/flutter")
+add_subdirectory(${FLUTTER_MANAGED_DIR})
+
+# System-level dependencies.
+find_package(PkgConfig REQUIRED)
+pkg_check_modules(GTK REQUIRED IMPORTED_TARGET gtk+-3.0)
+
+# Application build; see runner/CMakeLists.txt.
+add_subdirectory("runner")
+
+# Run the Flutter tool portions of the build. This must not be removed.
+add_dependencies(${BINARY_NAME} flutter_assemble)
+
+# Only the install-generated bundle's copy of the executable will launch
+# correctly, since the resources must in the right relative locations. To avoid
+# people trying to run the unbundled copy, put it in a subdirectory instead of
+# the default top-level location.
+set_target_properties(${BINARY_NAME}
+  PROPERTIES
+  RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/intermediates_do_not_run"
+)
+
+
+# Generated plugin build rules, which manage building the plugins and adding
+# them to the application.
+include(flutter/generated_plugins.cmake)
+
+
+# === Installation ===
+# By default, "installing" just makes a relocatable bundle in the build
+# directory.
+set(BUILD_BUNDLE_DIR "${PROJECT_BINARY_DIR}/bundle")
+if(CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
+  set(CMAKE_INSTALL_PREFIX "${BUILD_BUNDLE_DIR}" CACHE PATH "..." FORCE)
+endif()
+
+# Start with a clean build bundle directory every time.
+install(CODE "
+  file(REMOVE_RECURSE \"${BUILD_BUNDLE_DIR}/\")
+  " COMPONENT Runtime)
+
+set(INSTALL_BUNDLE_DATA_DIR "${CMAKE_INSTALL_PREFIX}/data")
+set(INSTALL_BUNDLE_LIB_DIR "${CMAKE_INSTALL_PREFIX}/lib")
+
+install(TARGETS ${BINARY_NAME} RUNTIME DESTINATION "${CMAKE_INSTALL_PREFIX}"
+  COMPONENT Runtime)
+
+install(FILES "${FLUTTER_ICU_DATA_FILE}" DESTINATION "${INSTALL_BUNDLE_DATA_DIR}"
+  COMPONENT Runtime)
+
+install(FILES "${FLUTTER_LIBRARY}" DESTINATION "${INSTALL_BUNDLE_LIB_DIR}"
+  COMPONENT Runtime)
+
+foreach(bundled_library ${PLUGIN_BUNDLED_LIBRARIES})
+  install(FILES "${bundled_library}"
+    DESTINATION "${INSTALL_BUNDLE_LIB_DIR}"
+    COMPONENT Runtime)
+endforeach(bundled_library)
+
+# Copy the native assets provided by the build.dart from all packages.
+set(NATIVE_ASSETS_DIR "${PROJECT_BUILD_DIR}native_assets/linux/")
+install(DIRECTORY "${NATIVE_ASSETS_DIR}"
+   DESTINATION "${INSTALL_BUNDLE_LIB_DIR}"
+   COMPONENT Runtime)
+
+# Fully re-copy the assets directory on each build to avoid having stale files
+# from a previous install.
+set(FLUTTER_ASSET_DIR_NAME "flutter_assets")
+install(CODE "
+  file(REMOVE_RECURSE \"${INSTALL_BUNDLE_DATA_DIR}/${FLUTTER_ASSET_DIR_NAME}\")
+  " COMPONENT Runtime)
+install(DIRECTORY "${PROJECT_BUILD_DIR}/${FLUTTER_ASSET_DIR_NAME}"
+  DESTINATION "${INSTALL_BUNDLE_DATA_DIR}" COMPONENT Runtime)
+
+# Install the AOT library on non-Debug builds only.
+if(NOT CMAKE_BUILD_TYPE MATCHES "Debug")
+  install(FILES "${AOT_LIBRARY}" DESTINATION "${INSTALL_BUNDLE_LIB_DIR}"
+    COMPONENT Runtime)
+endif()

--- a/examples/catalog_gallery/linux/flutter/CMakeLists.txt
+++ b/examples/catalog_gallery/linux/flutter/CMakeLists.txt
@@ -1,0 +1,88 @@
+# This file controls Flutter-level build steps. It should not be edited.
+cmake_minimum_required(VERSION 3.10)
+
+set(EPHEMERAL_DIR "${CMAKE_CURRENT_SOURCE_DIR}/ephemeral")
+
+# Configuration provided via flutter tool.
+include(${EPHEMERAL_DIR}/generated_config.cmake)
+
+# TODO: Move the rest of this into files in ephemeral. See
+# https://github.com/flutter/flutter/issues/57146.
+
+# Serves the same purpose as list(TRANSFORM ... PREPEND ...),
+# which isn't available in 3.10.
+function(list_prepend LIST_NAME PREFIX)
+    set(NEW_LIST "")
+    foreach(element ${${LIST_NAME}})
+        list(APPEND NEW_LIST "${PREFIX}${element}")
+    endforeach(element)
+    set(${LIST_NAME} "${NEW_LIST}" PARENT_SCOPE)
+endfunction()
+
+# === Flutter Library ===
+# System-level dependencies.
+find_package(PkgConfig REQUIRED)
+pkg_check_modules(GTK REQUIRED IMPORTED_TARGET gtk+-3.0)
+pkg_check_modules(GLIB REQUIRED IMPORTED_TARGET glib-2.0)
+pkg_check_modules(GIO REQUIRED IMPORTED_TARGET gio-2.0)
+
+set(FLUTTER_LIBRARY "${EPHEMERAL_DIR}/libflutter_linux_gtk.so")
+
+# Published to parent scope for install step.
+set(FLUTTER_LIBRARY ${FLUTTER_LIBRARY} PARENT_SCOPE)
+set(FLUTTER_ICU_DATA_FILE "${EPHEMERAL_DIR}/icudtl.dat" PARENT_SCOPE)
+set(PROJECT_BUILD_DIR "${PROJECT_DIR}/build/" PARENT_SCOPE)
+set(AOT_LIBRARY "${PROJECT_DIR}/build/lib/libapp.so" PARENT_SCOPE)
+
+list(APPEND FLUTTER_LIBRARY_HEADERS
+  "fl_basic_message_channel.h"
+  "fl_binary_codec.h"
+  "fl_binary_messenger.h"
+  "fl_dart_project.h"
+  "fl_engine.h"
+  "fl_json_message_codec.h"
+  "fl_json_method_codec.h"
+  "fl_message_codec.h"
+  "fl_method_call.h"
+  "fl_method_channel.h"
+  "fl_method_codec.h"
+  "fl_method_response.h"
+  "fl_plugin_registrar.h"
+  "fl_plugin_registry.h"
+  "fl_standard_message_codec.h"
+  "fl_standard_method_codec.h"
+  "fl_string_codec.h"
+  "fl_value.h"
+  "fl_view.h"
+  "flutter_linux.h"
+)
+list_prepend(FLUTTER_LIBRARY_HEADERS "${EPHEMERAL_DIR}/flutter_linux/")
+add_library(flutter INTERFACE)
+target_include_directories(flutter INTERFACE
+  "${EPHEMERAL_DIR}"
+)
+target_link_libraries(flutter INTERFACE "${FLUTTER_LIBRARY}")
+target_link_libraries(flutter INTERFACE
+  PkgConfig::GTK
+  PkgConfig::GLIB
+  PkgConfig::GIO
+)
+add_dependencies(flutter flutter_assemble)
+
+# === Flutter tool backend ===
+# _phony_ is a non-existent file to force this command to run every time,
+# since currently there's no way to get a full input/output list from the
+# flutter tool.
+add_custom_command(
+  OUTPUT ${FLUTTER_LIBRARY} ${FLUTTER_LIBRARY_HEADERS}
+    ${CMAKE_CURRENT_BINARY_DIR}/_phony_
+  COMMAND ${CMAKE_COMMAND} -E env
+    ${FLUTTER_TOOL_ENVIRONMENT}
+    "${FLUTTER_ROOT}/packages/flutter_tools/bin/tool_backend.sh"
+      ${FLUTTER_TARGET_PLATFORM} ${CMAKE_BUILD_TYPE}
+  VERBATIM
+)
+add_custom_target(flutter_assemble DEPENDS
+  "${FLUTTER_LIBRARY}"
+  ${FLUTTER_LIBRARY_HEADERS}
+)

--- a/examples/catalog_gallery/linux/runner/CMakeLists.txt
+++ b/examples/catalog_gallery/linux/runner/CMakeLists.txt
@@ -1,0 +1,26 @@
+cmake_minimum_required(VERSION 3.13)
+project(runner LANGUAGES CXX)
+
+# Define the application target. To change its name, change BINARY_NAME in the
+# top-level CMakeLists.txt, not the value here, or `flutter run` will no longer
+# work.
+#
+# Any new source files that you add to the application should be added here.
+add_executable(${BINARY_NAME}
+  "main.cc"
+  "my_application.cc"
+  "${FLUTTER_MANAGED_DIR}/generated_plugin_registrant.cc"
+)
+
+# Apply the standard set of build settings. This can be removed for applications
+# that need different build settings.
+apply_standard_settings(${BINARY_NAME})
+
+# Add preprocessor definitions for the application ID.
+add_definitions(-DAPPLICATION_ID="${APPLICATION_ID}")
+
+# Add dependency libraries. Add any application-specific dependencies here.
+target_link_libraries(${BINARY_NAME} PRIVATE flutter)
+target_link_libraries(${BINARY_NAME} PRIVATE PkgConfig::GTK)
+
+target_include_directories(${BINARY_NAME} PRIVATE "${CMAKE_SOURCE_DIR}")

--- a/examples/catalog_gallery/linux/runner/main.cc
+++ b/examples/catalog_gallery/linux/runner/main.cc
@@ -1,0 +1,10 @@
+// Copyright 2025 The Flutter Authors.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "my_application.h"
+
+int main(int argc, char** argv) {
+  g_autoptr(MyApplication) app = my_application_new();
+  return g_application_run(G_APPLICATION(app), argc, argv);
+}

--- a/examples/catalog_gallery/linux/runner/my_application.cc
+++ b/examples/catalog_gallery/linux/runner/my_application.cc
@@ -1,0 +1,150 @@
+// Copyright 2025 The Flutter Authors.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "my_application.h"
+
+#include <flutter_linux/flutter_linux.h>
+#ifdef GDK_WINDOWING_X11
+#include <gdk/gdkx.h>
+#endif
+
+#include "flutter/generated_plugin_registrant.h"
+
+struct _MyApplication {
+  GtkApplication parent_instance;
+  char **dart_entrypoint_arguments;
+};
+
+G_DEFINE_TYPE(MyApplication, my_application, GTK_TYPE_APPLICATION)
+
+// Called when first Flutter frame received.
+static void first_frame_cb(MyApplication *self, FlView *view) {
+  gtk_widget_show(gtk_widget_get_toplevel(GTK_WIDGET(view)));
+}
+
+// Implements GApplication::activate.
+static void my_application_activate(GApplication *application) {
+  MyApplication *self = MY_APPLICATION(application);
+  GtkWindow *window =
+      GTK_WINDOW(gtk_application_window_new(GTK_APPLICATION(application)));
+
+  // Use a header bar when running in GNOME as this is the common style used
+  // by applications and is the setup most users will be using (e.g. Ubuntu
+  // desktop).
+  // If running on X and not using GNOME then just use a traditional title bar
+  // in case the window manager does more exotic layout, e.g. tiling.
+  // If running on Wayland assume the header bar will work (may need changing
+  // if future cases occur).
+  gboolean use_header_bar = TRUE;
+#ifdef GDK_WINDOWING_X11
+  GdkScreen *screen = gtk_window_get_screen(window);
+  if (GDK_IS_X11_SCREEN(screen)) {
+    const gchar *wm_name = gdk_x11_screen_get_window_manager_name(screen);
+    if (g_strcmp0(wm_name, "GNOME Shell") != 0) {
+      use_header_bar = FALSE;
+    }
+  }
+#endif
+  if (use_header_bar) {
+    GtkHeaderBar *header_bar = GTK_HEADER_BAR(gtk_header_bar_new());
+    gtk_widget_show(GTK_WIDGET(header_bar));
+    gtk_header_bar_set_title(header_bar, "catalog_gallery");
+    gtk_header_bar_set_show_close_button(header_bar, TRUE);
+    gtk_window_set_titlebar(window, GTK_WIDGET(header_bar));
+  } else {
+    gtk_window_set_title(window, "catalog_gallery");
+  }
+
+  gtk_window_set_default_size(window, 1280, 720);
+
+  g_autoptr(FlDartProject) project = fl_dart_project_new();
+  fl_dart_project_set_dart_entrypoint_arguments(
+      project, self->dart_entrypoint_arguments);
+
+  FlView *view = fl_view_new(project);
+  GdkRGBA background_color;
+  // Background defaults to black, override it here if necessary, e.g. #00000000
+  // for transparent.
+  gdk_rgba_parse(&background_color, "#000000");
+  fl_view_set_background_color(view, &background_color);
+  gtk_widget_show(GTK_WIDGET(view));
+  gtk_container_add(GTK_CONTAINER(window), GTK_WIDGET(view));
+
+  // Show the window when Flutter renders.
+  // Requires the view to be realized so we can start rendering.
+  g_signal_connect_swapped(view, "first-frame", G_CALLBACK(first_frame_cb),
+                           self);
+  gtk_widget_realize(GTK_WIDGET(view));
+
+  fl_register_plugins(FL_PLUGIN_REGISTRY(view));
+
+  gtk_widget_grab_focus(GTK_WIDGET(view));
+}
+
+// Implements GApplication::local_command_line.
+static gboolean my_application_local_command_line(GApplication *application,
+                                                  gchar ***arguments,
+                                                  int *exit_status) {
+  MyApplication *self = MY_APPLICATION(application);
+  // Strip out the first argument as it is the binary name.
+  self->dart_entrypoint_arguments = g_strdupv(*arguments + 1);
+
+  g_autoptr(GError) error = nullptr;
+  if (!g_application_register(application, nullptr, &error)) {
+    g_warning("Failed to register: %s", error->message);
+    *exit_status = 1;
+    return TRUE;
+  }
+
+  g_application_activate(application);
+  *exit_status = 0;
+
+  return TRUE;
+}
+
+// Implements GApplication::startup.
+static void my_application_startup(GApplication *application) {
+  // Perform any actions required at application startup.
+
+  G_APPLICATION_CLASS(my_application_parent_class)->startup(application);
+}
+
+// Implements GApplication::shutdown.
+static void my_application_shutdown(GApplication *application) {
+  // MyApplication* self = MY_APPLICATION(object);
+
+  // Perform any actions required at application shutdown.
+
+  G_APPLICATION_CLASS(my_application_parent_class)->shutdown(application);
+}
+
+// Implements GObject::dispose.
+static void my_application_dispose(GObject *object) {
+  MyApplication *self = MY_APPLICATION(object);
+  g_clear_pointer(&self->dart_entrypoint_arguments, g_strfreev);
+  G_OBJECT_CLASS(my_application_parent_class)->dispose(object);
+}
+
+static void my_application_class_init(MyApplicationClass *klass) {
+  G_APPLICATION_CLASS(klass)->activate = my_application_activate;
+  G_APPLICATION_CLASS(klass)->local_command_line =
+      my_application_local_command_line;
+  G_APPLICATION_CLASS(klass)->startup = my_application_startup;
+  G_APPLICATION_CLASS(klass)->shutdown = my_application_shutdown;
+  G_OBJECT_CLASS(klass)->dispose = my_application_dispose;
+}
+
+static void my_application_init(MyApplication *self) {}
+
+MyApplication *my_application_new() {
+  // Set the program name to the application ID, which helps various systems
+  // like GTK and desktop environments map this running application to its
+  // corresponding .desktop file. This ensures better integration by allowing
+  // the application to be recognized beyond its binary name.
+  g_set_prgname(APPLICATION_ID);
+
+  return MY_APPLICATION(g_object_new(my_application_get_type(),
+                                     "application-id", APPLICATION_ID, "flags",
+                                     G_APPLICATION_NON_UNIQUE, nullptr));
+}

--- a/examples/catalog_gallery/linux/runner/my_application.h
+++ b/examples/catalog_gallery/linux/runner/my_application.h
@@ -1,0 +1,25 @@
+// Copyright 2025 The Flutter Authors.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef FLUTTER_MY_APPLICATION_H_
+#define FLUTTER_MY_APPLICATION_H_
+
+#include <gtk/gtk.h>
+
+G_DECLARE_FINAL_TYPE(MyApplication,
+                     my_application,
+                     MY,
+                     APPLICATION,
+                     GtkApplication)
+
+/**
+ * my_application_new:
+ *
+ * Creates a new Flutter-based application.
+ *
+ * Returns: a new #MyApplication.
+ */
+MyApplication* my_application_new();
+
+#endif  // FLUTTER_MY_APPLICATION_H_

--- a/packages/flutter_genui/lib/src/catalog/core_widgets/audio_player.dart
+++ b/packages/flutter_genui/lib/src/catalog/core_widgets/audio_player.dart
@@ -29,7 +29,10 @@ final audioPlayer = CatalogItem(
         required context,
         required dataContext,
       }) {
-        return const Placeholder(child: Center(child: Text('AudioPlayer')));
+        return ConstrainedBox(
+          constraints: const BoxConstraints(maxWidth: 200, maxHeight: 100),
+          child: const Placeholder(child: Center(child: Text('AudioPlayer'))),
+        );
       },
   exampleData: [
     () => {

--- a/packages/flutter_genui/lib/src/catalog/core_widgets/column.dart
+++ b/packages/flutter_genui/lib/src/catalog/core_widgets/column.dart
@@ -117,7 +117,13 @@ final column = CatalogItem(
           'id': 'advice_column',
           'widget': {
             'Column': {
-              'children': ['advice_text', 'advice_options', 'submit_button'],
+              'children': {
+                'explicitList': [
+                  'advice_text',
+                  'advice_options',
+                  'submit_button',
+                ],
+              },
             },
           },
         },
@@ -144,7 +150,7 @@ final column = CatalogItem(
           'widget': {
             'Button': {
               'child': 'submit_button_text',
-              'action': {'actionName': 'submit'},
+              'action': {'name': 'submit'},
             },
           },
         },

--- a/packages/flutter_genui/lib/src/catalog/core_widgets/date_time_input.dart
+++ b/packages/flutter_genui/lib/src/catalog/core_widgets/date_time_input.dart
@@ -99,8 +99,11 @@ final dateTimeInput = CatalogItem(
       'widgets': [
         {
           'id': 'datetime',
-          'type': 'DateTimeInput',
-          'value': {'path': '/myDateTime'},
+          'widget': {
+            'DateTimeInput': {
+              'value': {'path': '/myDateTime'},
+            },
+          },
         },
       ],
     },

--- a/packages/flutter_genui/lib/src/catalog/core_widgets/divider.dart
+++ b/packages/flutter_genui/lib/src/catalog/core_widgets/divider.dart
@@ -42,7 +42,10 @@ final divider = CatalogItem(
     () => {
       'root': 'divider',
       'widgets': [
-        {'id': 'divider', 'type': 'Divider'},
+        {
+          'id': 'divider',
+          'widget': {'Divider': <String, Object?>{}},
+        },
       ],
     },
   ],

--- a/packages/flutter_genui/lib/src/catalog/core_widgets/heading.dart
+++ b/packages/flutter_genui/lib/src/catalog/core_widgets/heading.dart
@@ -63,9 +63,12 @@ final heading = CatalogItem(
       'widgets': [
         {
           'id': 'heading',
-          'type': 'Heading',
-          'text': {'literalString': 'This is a heading'},
-          'level': '1',
+          'widget': {
+            'Heading': {
+              'text': {'literalString': 'This is a heading'},
+              'level': '1',
+            },
+          },
         },
       ],
     },

--- a/packages/flutter_genui/lib/src/catalog/core_widgets/list.dart
+++ b/packages/flutter_genui/lib/src/catalog/core_widgets/list.dart
@@ -67,20 +67,29 @@ final list = CatalogItem(
       'widgets': [
         {
           'id': 'list',
-          'type': 'List',
-          'children': {
-            'explicitList': ['text1', 'text2'],
+          'widget': {
+            'List': {
+              'children': {
+                'explicitList': ['text1', 'text2'],
+              },
+            },
           },
         },
         {
           'id': 'text1',
-          'type': 'Text',
-          'text': {'literalString': 'First'},
+          'widget': {
+            'Text': {
+              'text': {'literalString': 'First'},
+            },
+          },
         },
         {
           'id': 'text2',
-          'type': 'Text',
-          'text': {'literalString': 'Second'},
+          'widget': {
+            'Text': {
+              'text': {'literalString': 'Second'},
+            },
+          },
         },
       ],
     },

--- a/packages/flutter_genui/lib/src/catalog/core_widgets/modal.dart
+++ b/packages/flutter_genui/lib/src/catalog/core_widgets/modal.dart
@@ -54,20 +54,42 @@ final modal = CatalogItem(
       'widgets': [
         {
           'id': 'modal',
-          'type': 'Modal',
-          'entryPointChild': 'button',
-          'contentChild': 'text',
+          'widget': {
+            'Modal': {'entryPointChild': 'button', 'contentChild': 'text'},
+          },
         },
         {
           'id': 'button',
-          'type': 'Button',
-          'label': {'literalString': 'Open Modal'},
-          'action': {'name': 'showModal'},
+          'widget': {
+            'Button': {
+              'child': 'button_text',
+              'action': {
+                'name': 'showModal',
+                'context': [
+                  {
+                    'key': 'modalId',
+                    'value': {'literalString': 'modal'},
+                  },
+                ],
+              },
+            },
+          },
+        },
+        {
+          'id': 'button_text',
+          'widget': {
+            'Text': {
+              'text': {'literalString': 'Open Modal'},
+            },
+          },
         },
         {
           'id': 'text',
-          'type': 'Text',
-          'text': {'literalString': 'This is a modal.'},
+          'widget': {
+            'Text': {
+              'text': {'literalString': 'This is a modal.'},
+            },
+          },
         },
       ],
     },

--- a/packages/flutter_genui/lib/src/catalog/core_widgets/multiple_choice.dart
+++ b/packages/flutter_genui/lib/src/catalog/core_widgets/multiple_choice.dart
@@ -105,18 +105,21 @@ final multipleChoice = CatalogItem(
       'widgets': [
         {
           'id': 'multiple_choice',
-          'type': 'MultipleChoice',
-          'selections': {'path': '/mySelections'},
-          'options': [
-            {
-              'label': {'literalString': 'Option 1'},
-              'value': '1',
+          'widget': {
+            'MultipleChoice': {
+              'selections': {'path': '/mySelections'},
+              'options': [
+                {
+                  'label': {'literalString': 'Option 1'},
+                  'value': '1',
+                },
+                {
+                  'label': {'literalString': 'Option 2'},
+                  'value': '2',
+                },
+              ],
             },
-            {
-              'label': {'literalString': 'Option 2'},
-              'value': '2',
-            },
-          ],
+          },
         },
       ],
     },

--- a/packages/flutter_genui/lib/src/catalog/core_widgets/row.dart
+++ b/packages/flutter_genui/lib/src/catalog/core_widgets/row.dart
@@ -113,20 +113,29 @@ final row = CatalogItem(
       'widgets': [
         {
           'id': 'row',
-          'type': 'Row',
-          'children': {
-            'explicitList': ['text1', 'text2'],
+          'widget': {
+            'Row': {
+              'children': {
+                'explicitList': ['text1', 'text2'],
+              },
+            },
           },
         },
         {
           'id': 'text1',
-          'type': 'Text',
-          'text': {'literalString': 'First'},
+          'widget': {
+            'Text': {
+              'text': {'literalString': 'First'},
+            },
+          },
         },
         {
           'id': 'text2',
-          'type': 'Text',
-          'text': {'literalString': 'Second'},
+          'widget': {
+            'Text': {
+              'text': {'literalString': 'Second'},
+            },
+          },
         },
       ],
     },

--- a/packages/flutter_genui/lib/src/catalog/core_widgets/slider.dart
+++ b/packages/flutter_genui/lib/src/catalog/core_widgets/slider.dart
@@ -76,8 +76,11 @@ final slider = CatalogItem(
       'widgets': [
         {
           'id': 'slider',
-          'type': 'Slider',
-          'value': {'path': '/myValue'},
+          'widget': {
+            'Slider': {
+              'value': {'path': '/myValue'},
+            },
+          },
         },
       ],
     },

--- a/packages/flutter_genui/lib/src/catalog/core_widgets/tabs.dart
+++ b/packages/flutter_genui/lib/src/catalog/core_widgets/tabs.dart
@@ -79,27 +79,36 @@ final tabs = CatalogItem(
       'widgets': [
         {
           'id': 'tabs',
-          'type': 'Tabs',
-          'tabItems': [
-            {
-              'title': {'literalString': 'Tab 1'},
-              'child': 'text1',
+          'widget': {
+            'Tabs': {
+              'tabItems': [
+                {
+                  'title': {'literalString': 'Tab 1'},
+                  'child': 'text1',
+                },
+                {
+                  'title': {'literalString': 'Tab 2'},
+                  'child': 'text2',
+                },
+              ],
             },
-            {
-              'title': {'literalString': 'Tab 2'},
-              'child': 'text2',
-            },
-          ],
+          },
         },
         {
           'id': 'text1',
-          'type': 'Text',
-          'text': {'literalString': 'This is the first tab.'},
+          'widget': {
+            'Text': {
+              'text': {'literalString': 'This is the first tab.'},
+            },
+          },
         },
         {
           'id': 'text2',
-          'type': 'Text',
-          'text': {'literalString': 'This is the second tab.'},
+          'widget': {
+            'Text': {
+              'text': {'literalString': 'This is the second tab.'},
+            },
+          },
         },
       ],
     },

--- a/packages/flutter_genui/lib/src/catalog/core_widgets/video.dart
+++ b/packages/flutter_genui/lib/src/catalog/core_widgets/video.dart
@@ -29,7 +29,10 @@ final video = CatalogItem(
         required context,
         required dataContext,
       }) {
-        return const Placeholder(child: Center(child: Text('Video')));
+        return ConstrainedBox(
+          constraints: const BoxConstraints(maxWidth: 200, maxHeight: 100),
+          child: const Placeholder(child: Center(child: Text('Video'))),
+        );
       },
   exampleData: [
     () => {

--- a/packages/flutter_genui/lib/src/development_utilities/catalog_view.dart
+++ b/packages/flutter_genui/lib/src/development_utilities/catalog_view.dart
@@ -63,12 +63,23 @@ class _DebugCatalogViewState extends State<DebugCatalogView> {
           .map((e) {
             final widget = e as JsonMap;
             final widgetMap = widget['widget'] as JsonMap?;
-            if (widgetMap == null) {
+            if (widgetMap != null) {
+              return Component(
+                id: widget['id'] as String,
+                componentProperties: widgetMap,
+              );
+            }
+            // Handle the other format.
+            final type = widget['type'] as String?;
+            if (type == null) {
               return null;
             }
+            final properties = Map<String, Object?>.from(widget);
+            properties.remove('id');
+            properties.remove('type');
             return Component(
               id: widget['id'] as String,
-              componentProperties: widgetMap.values.first as JsonMap,
+              componentProperties: {type: properties},
             );
           })
           .whereType<Component>()
@@ -99,12 +110,15 @@ class _DebugCatalogViewState extends State<DebugCatalogView> {
       itemCount: surfaceIds.length,
       itemBuilder: (BuildContext context, int index) {
         final surfaceId = surfaceIds[index];
-        return ListTile(
-          title: Text(
-            '$surfaceId:',
-            style: const TextStyle(decoration: TextDecoration.underline),
+        return ConstrainedBox(
+          constraints: const BoxConstraints(maxHeight: 200),
+          child: ListTile(
+            title: Text(
+              '$surfaceId:',
+              style: const TextStyle(decoration: TextDecoration.underline),
+            ),
+            subtitle: GenUiSurface(host: _genUi, surfaceId: surfaceId),
           ),
-          subtitle: GenUiSurface(host: _genUi, surfaceId: surfaceId),
         );
       },
     );

--- a/packages/flutter_genui/lib/src/model/catalog.dart
+++ b/packages/flutter_genui/lib/src/model/catalog.dart
@@ -79,7 +79,7 @@ class Catalog {
 
     genUiLogger.info('Building widget ${item.name} with id $id');
     return item.widgetBuilder(
-      data: widgetData[widgetType]! as JsonMap,
+      data: JsonMap.from(widgetData[widgetType]! as Map),
       id: id,
       buildChild: buildChild,
       dispatchEvent: dispatchEvent,


### PR DESCRIPTION
## Summary of Changes

This pull request significantly improves the catalog gallery display and layout by addressing several rendering and data formatting issues. It makes the `DebugCatalogView` more robust in handling diverse example data structures and ensures core widgets are displayed correctly through consistent data formats and targeted layout adjustments. A critical fix for the `Modal` widget's action context is included, along with updates to related tests. Furthermore, this PR extends the `catalog_gallery` example's compatibility by adding full Linux platform support.

### Highlights

* **Robust DebugCatalogView**: The `DebugCatalogView` has been enhanced to correctly handle multiple `exampleData` formats, making it more resilient to variations in component examples.
* **Corrected Example Data Formats**: The `exampleData` for several core widgets (AudioPlayer, Column, DateTimeInput, Divider, Heading, List, Modal, MultipleChoice, Row, Slider, Tabs, Video) has been updated to a consistent format, resolving previous rendering issues.
* **Layout Fixes**: The `Column` widget is now wrapped in a `SizedBox` to prevent layout errors, and the `DebugCatalogView` utilizes `ConstrainedBox` within a `ListView.builder` to correctly size component previews, improving the overall display.
* **Modal Widget Context**: The `Modal` widget's example data now correctly includes the `modalId` in the action context, which fixes a null pointer exception.
* **Linux Platform Support**: New CMake files and C++ runner code have been added to enable Linux platform support for the `catalog_gallery` example.

<details>
<summary><b>Changelog</b></summary>

* **examples/catalog_gallery/.metadata**
    * Updated Flutter revision to "e20c5f5594a36affb23de6c49b9dbc4454b69b33" and channel to "main".
    * Streamlined migration platform entries to only root and linux, removing entries for Android, iOS, macOS, Web, and Windows.
* **examples/catalog_gallery/linux/.gitignore**
    * Added `flutter/ephemeral` to the gitignore file.
* **examples/catalog_gallery/linux/CMakeLists.txt**
    * Added new CMake configuration for the Linux build of the catalog gallery example.
* **examples/catalog_gallery/linux/flutter/CMakeLists.txt**
    * Added Flutter-level CMake build steps specifically for Linux.
* **examples/catalog_gallery/linux/runner/CMakeLists.txt**
    * Added CMake configuration for the application runner on Linux.
* **examples/catalog_gallery/linux/runner/main.cc**
    * Added the main C++ file for the Linux runner application.
* **examples/catalog_gallery/linux/runner/my_application.cc**
    * Added the C++ application class implementation for the Linux runner.
* **examples/catalog_gallery/linux/runner/my_application.h**
    * Added the header file for the C++ application class on Linux.
* **packages/flutter_genui/lib/src/catalog/core_widgets/audio_player.dart**
    * Wrapped the `Placeholder` widget in a `ConstrainedBox` with `maxWidth` and `maxHeight` to limit its size in the catalog display.
* **packages/flutter_genui/lib/src/catalog/core_widgets/column.dart**
    * Updated the `Column` widget's `children` format to use an `explicitList` within a map.
    * Changed `actionName` to `name` for consistency in button actions within example data.
* **packages/flutter_genui/lib/src/catalog/core_widgets/date_time_input.dart**
    * Refactored `exampleData` to use a nested `widget` map for `DateTimeInput` instead of a direct `type` field.
* **packages/flutter_genui/lib/src/catalog/core_widgets/divider.dart**
    * Refactored `exampleData` to use a nested `widget` map for `Divider` instead of a direct `type` field.
* **packages/flutter_genui/lib/src/catalog/core_widgets/heading.dart**
    * Refactored `exampleData` to use a nested `widget` map for `Heading` instead of a direct `type` field.
* **packages/flutter_genui/lib/src/catalog/core_widgets/list.dart**
    * Refactored `exampleData` to use nested `widget` maps for `List` and `Text` components.
* **packages/flutter_genui/lib/src/catalog/core_widgets/modal.dart**
    * Updated `exampleData` to use a nested `widget` map for `Modal` and `Button`.
    * Added `modalId` to the action context of the `Button` to fix a null pointer exception.
    * Introduced a `button_text` widget for the `Modal` example.
* **packages/flutter_genui/lib/src/catalog/core_widgets/multiple_choice.dart**
    * Refactored `exampleData` to use a nested `widget` map for `MultipleChoice`.
* **packages/flutter_genui/lib/src/catalog/core_widgets/row.dart**
    * Refactored `exampleData` to use nested `widget` maps for `Row` and `Text` components.
* **packages/flutter_genui/lib/src/catalog/core_widgets/slider.dart**
    * Refactored `exampleData` to use a nested `widget` map for `Slider`.
* **packages/flutter_genui/lib/src/catalog/core_widgets/tabs.dart**
    * Refactored `exampleData` to use nested `widget` maps for `Tabs` and `Text` components.
* **packages/flutter_genui/lib/src/catalog/core_widgets/video.dart**
    * Wrapped the `Placeholder` widget in a `ConstrainedBox` with `maxWidth` and `maxHeight` to limit its size in the catalog display.
* **packages/flutter_genui/lib/src/development_utilities/catalog_view.dart**
    * Enhanced `_DebugCatalogViewState` to handle multiple `exampleData` formats, supporting both direct `type` and nested `widget` structures.
    * Introduced a `_surfacesCreated` state and `CircularProgressIndicator` for loading indication during surface creation.
    * Refactored the `build` method to improve layout using `Column`, `Expanded`, and `ConstrainedBox` for better component preview sizing.
* **packages/flutter_genui/lib/src/model/catalog.dart**
    * Modified how `widgetData` is accessed to ensure proper type casting from `Map` to `JsonMap`.
</details>
