### PR TITLE
Fix support for setting custom models in FirebaseAiClient

### DIFF
--- a/packages/flutter_genui_firebase_ai/lib/flutter_genui_firebase_ai.dart
+++ b/packages/flutter_genui_firebase_ai/lib/flutter_genui_firebase_ai.dart
@@ -4,4 +4,5 @@
 
 export 'src/firebase_ai_client.dart';
 export 'src/gemini_content_converter.dart';
+export 'src/gemini_generative_model.dart';
 export 'src/gemini_schema_adapter.dart';


### PR DESCRIPTION
Add an export of `gemini_generative_model.dart` from the umbrella import file which is necessary so that apps can use code like:

```dart
    final aiClient = FirebaseAiClient(
      systemInstruction:
          'You are a helpful assistant',
      tools: _genUiManager.getTools(),
      modelCreator:
          ({required configuration, systemInstruction, tools, toolConfig}) {
            return GeminiGenerativeModel(
              FirebaseAI.googleAI().generativeModel(
                model: 'gemini-2.5-flash-lite',
                systemInstruction: systemInstruction,
                tools: tools,
                toolConfig: toolConfig,
              ),
            );
          },
    );
```

Previously, the symbol `GeminiGenerativeModel` was not visible, so this was not possible.