### PR TITLE
Reduce meta version requirement

### DIFF
--- a/packages/json_schema_builder/CHANGELOG.md
+++ b/packages/json_schema_builder/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - Use [`email_validator`](https://pub.dev/packages/email_validator) package to
   validate emails instead of a regular expression.
+- Reduce required version for `meta` package to 1.16.0.
 
 ## 0.1.2
 

--- a/packages/json_schema_builder/pubspec.yaml
+++ b/packages/json_schema_builder/pubspec.yaml
@@ -20,7 +20,7 @@ dependencies:
   email_validator: ^3.0.0
   http: ^1.4.0
   intl: ^0.20.2
-  meta: ^1.17.0
+  meta: ^1.16.0
 
 dev_dependencies:
   dart_flutter_team_lints: ^3.5.2


### PR DESCRIPTION
# Description

This reduces the required version of the `meta` library to be compatible with the pinned version on the Flutter stable branch, and updates the CHANGELOG in preparation for publishing.

# Related Issues

- https://github.com/flutter/genui/issues/382