### PR TITLE
Use the published version of `json_schema_builder`

### DIFF
--- a/examples/catalog_gallery/pubspec.yaml
+++ b/examples/catalog_gallery/pubspec.yaml
@@ -14,8 +14,7 @@ dependencies:
     sdk: flutter
   flutter_genui:
     path: ../../packages/flutter_genui
-  json_schema_builder:
-    path: ../../packages/json_schema_builder
+  json_schema_builder: ^0.1.3
 
 dev_dependencies:
   dart_flutter_team_lints: ^3.5.2

--- a/examples/custom_backend/pubspec.yaml
+++ b/examples/custom_backend/pubspec.yaml
@@ -16,8 +16,7 @@ dependencies:
     path: ../../packages/flutter_genui
   http: ^1.5.0
   intl: ^0.20.2
-  json_schema_builder:
-    path: ../../packages/json_schema_builder
+  json_schema_builder: ^0.1.3
 
 dev_dependencies:
   build_runner: ^2.9.0

--- a/examples/travel_app/pubspec.yaml
+++ b/examples/travel_app/pubspec.yaml
@@ -21,8 +21,7 @@ dependencies:
     path: ../../packages/flutter_genui_firebase_ai
   gpt_markdown: ^1.1.4
   intl: ^0.20.2
-  json_schema_builder:
-    path: ../../packages/json_schema_builder
+  json_schema_builder: ^0.1.3
   logging: ^1.3.0
 
 dev_dependencies:

--- a/packages/flutter_genui/pubspec.yaml
+++ b/packages/flutter_genui/pubspec.yaml
@@ -18,8 +18,7 @@ dependencies:
   collection: ^1.19.1
   flutter:
     sdk: flutter
-  json_schema_builder:
-    path: ../json_schema_builder
+  json_schema_builder: ^0.1.3
   logging: ^1.3.0
 
 dev_dependencies:

--- a/packages/flutter_genui_firebase_ai/pubspec.yaml
+++ b/packages/flutter_genui_firebase_ai/pubspec.yaml
@@ -20,8 +20,7 @@ dependencies:
     sdk: flutter
   flutter_genui:
     path: ../flutter_genui
-  json_schema_builder:
-    path: ../json_schema_builder
+  json_schema_builder: ^0.1.3
 
 dev_dependencies:
   dart_flutter_team_lints: ^3.5.2

--- a/packages/spikes/fcp_client/example/pubspec.yaml
+++ b/packages/spikes/fcp_client/example/pubspec.yaml
@@ -18,8 +18,7 @@ dependencies:
   cupertino_icons: ^1.0.8
   flutter_driver:
     sdk: flutter
-  json_schema_builder:
-    path: ../../../json_schema_builder
+  json_schema_builder: ^0.1.3
 
 dev_dependencies:
   test: ^1.26.2

--- a/packages/spikes/fcp_client/pubspec.yaml
+++ b/packages/spikes/fcp_client/pubspec.yaml
@@ -19,8 +19,7 @@ dependencies:
     sdk: flutter
   json_patch: ^3.0.0
   json_schema: ^5.2.1
-  json_schema_builder:
-    path: ../../json_schema_builder
+  json_schema_builder: ^0.1.3
   platform: ^3.1.6
 
 dev_dependencies:


### PR DESCRIPTION
# Description

This uses the published version of `json_schema_builder` instead of the path reference.