### PR TITLE
Fix variable names in USAGE.md sample

### DIFF
--- a/packages/flutter_genui/USAGE.md
+++ b/packages/flutter_genui/USAGE.md
@@ -181,7 +181,7 @@ To receive and display generated UI:
      // Send a message containing the user's text to the agent.
      void _sendMessage(String text) {
        if (text.trim().isEmpty) return;
-       genUiConversation.sendRequest(UserMessage.text(text));
+       _genUiConversation.sendRequest(UserMessage.text(text));
      }
 
      // A callback invoked by the [GenUiConversation] when a new UI surface is generated.
@@ -215,7 +215,7 @@ To receive and display generated UI:
                  itemBuilder: (context, index) {
                    // For each surface, create a GenUiSurface to display it.
                    final id = _surfaceIds[index];
-                   return GenUiSurface(host: genUiConversation.host, surfaceId: id);
+                   return GenUiSurface(host: _genUiConversation.host, surfaceId: id);
                  },
                ),
              ),
@@ -337,7 +337,7 @@ final riddleCard = CatalogItem(
 Include your catalog items when instantiating `GenUiManager`.
 
 ```dart
-final genUiManager = GenUiManager(
+_genUiManager = GenUiManager(
   catalog: CoreCatalogItems.asCatalog().copyWith([riddleCard]),
 );
 ```
@@ -355,7 +355,7 @@ final aiClient = FirebaseAiClient(
       you should generate a RiddleCard that displays one new riddle related to that word.
       Each riddle should have both a question and an answer.
       ''',
-  tools: genUiManager.getTools(),
+  tools: _genUiManager.getTools(),
 );
 ```
 


### PR DESCRIPTION
# Description

The sample code blocks in the USAGE.md mix up the names of the same variables (`_genUiConversation` with `genUiConversation`, and `_genUiManager` with `genUiManager`), creating an error when following the sample instructions. 

This PR fixes that by updating them to use the same variables all through. 

## Pre-launch Checklist

- [x] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [x] I signed the [CLA].
- [x] I read the [Contributors Guide].
- [ ] I have added sample code updates to the [changelog].
- [x] I updated/added relevant documentation (doc comments with `///`).

If you need help, consider asking for advice on the #hackers-devrel channel on [Discord].

<!-- Links -->

[Flutter Style Guide]: https://github.com/flutter/flutter/blob/master/docs/contributing/Style-guide-for-Flutter-repo.md
[CLA]: https://cla.developers.google.com/
[Discord]: https://github.com/flutter/flutter/blob/master/docs/contributing/Chat.md
[Contributors Guide]: https://github.com/flutter/samples/blob/main/CONTRIBUTING.md
[changelog]: ../CHANGELOG.md
