### PR TITLE
Add Icon Component

### DIFF
--- a/packages/flutter_genui/lib/src/catalog/core_catalog.dart
+++ b/packages/flutter_genui/lib/src/catalog/core_catalog.dart
@@ -12,6 +12,7 @@ import 'core_widgets/column.dart' as column_item;
 import 'core_widgets/date_time_input.dart' as date_time_input_item;
 import 'core_widgets/divider.dart' as divider_item;
 import 'core_widgets/heading.dart' as heading_item;
+import 'core_widgets/icon.dart' as icon_item;
 import 'core_widgets/image.dart' as image_item;
 import 'core_widgets/list.dart' as list_item;
 import 'core_widgets/modal.dart' as modal_item;
@@ -61,6 +62,9 @@ class CoreCatalogItems {
   ///
   /// Supports different levels to indicate hierarchy.
   static final CatalogItem heading = heading_item.heading;
+
+  /// An icon.
+  static final CatalogItem icon = icon_item.icon;
 
   /// Represents a UI element for displaying image data from a URL or other
   /// source.
@@ -114,6 +118,7 @@ class CoreCatalogItems {
       dateTimeInput,
       divider,
       heading,
+      icon,
       image,
       list,
       modal,

--- a/packages/flutter_genui/lib/src/catalog/core_widgets/icon.dart
+++ b/packages/flutter_genui/lib/src/catalog/core_widgets/icon.dart
@@ -1,0 +1,147 @@
+// Copyright 2025 The Flutter Authors.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter/material.dart';
+import 'package:json_schema_builder/json_schema_builder.dart';
+
+import '../../model/a2ui_schemas.dart';
+import '../../model/catalog_item.dart';
+import '../../model/data_model.dart';
+import '../../primitives/simple_items.dart';
+
+final _schema = S.object(
+  properties: {
+    'name': A2uiSchemas.stringReference(
+      description:
+          '''The name of the icon to display. This can be a literal string ('literalString') or a reference to a value in the data model ('path', e.g. '/icon/name').''',
+      enumValues: AvailableIcons.allAvailable,
+    ),
+  },
+  required: ['name'],
+);
+
+extension type _IconData.fromMap(JsonMap _json) {
+  factory _IconData({required JsonMap name}) =>
+      _IconData.fromMap({'name': name});
+
+  JsonMap get nameMap => _json['name'] as JsonMap;
+
+  String? get literalName => nameMap['literalString'] as String?;
+  String? get namePath => nameMap['path'] as String?;
+}
+
+enum AvailableIcons {
+  add(Icons.add),
+  arrowBack(Icons.arrow_back),
+  arrowForward(Icons.arrow_forward),
+  build(Icons.build),
+  cameraAlt(Icons.camera_alt),
+  check(Icons.check),
+  close(Icons.close),
+  delete(Icons.delete),
+  download(Icons.download),
+  edit(Icons.edit),
+  event(Icons.event),
+  favorite(Icons.favorite),
+  home(Icons.home),
+  info(Icons.info),
+  locationOn(Icons.location_on),
+  lockOpen(Icons.lock_open),
+  lock(Icons.lock),
+  mail(Icons.mail),
+  menu(Icons.menu),
+  notificationsActive(Icons.notifications_active),
+  notifications(Icons.notifications),
+  payment(Icons.payment),
+  person(Icons.person),
+  phone(Icons.phone),
+  photoLibrary(Icons.photo_library),
+  search(Icons.search),
+  settings(Icons.settings),
+  share(Icons.share),
+  shoppingCart(Icons.shopping_cart),
+  upload(Icons.upload),
+  visibilityOff(Icons.visibility_off),
+  visibility(Icons.visibility);
+
+  const AvailableIcons(this.iconData);
+
+  final IconData iconData;
+
+  static List<String> get allAvailable =>
+      values.map<String>((icon) => icon.name).toList();
+
+  static AvailableIcons? fromName(String name) {
+    for (final iconName in AvailableIcons.values) {
+      if (iconName.name == name) {
+        return iconName;
+      }
+    }
+    return null;
+  }
+}
+
+/// A catalog item for an icon.
+///
+/// ### Parameters:
+///
+/// - `name`: The name of the icon to display.
+final icon = CatalogItem(
+  name: 'Icon',
+  dataSchema: _schema,
+  widgetBuilder:
+      ({
+        required data,
+        required id,
+        required buildChild,
+        required dispatchEvent,
+        required context,
+        required dataContext,
+        required getComponent,
+      }) {
+        final iconData = _IconData.fromMap(data as JsonMap);
+        final literalName = iconData.literalName;
+        final namePath = iconData.namePath;
+
+        if (literalName != null) {
+          final icon =
+              AvailableIcons.fromName(literalName)?.iconData ??
+              Icons.broken_image;
+          return Icon(icon);
+        }
+
+        if (namePath == null) {
+          return const Icon(Icons.broken_image);
+        }
+
+        final notifier = dataContext.subscribe<String>(DataPath(namePath));
+
+        return ValueListenableBuilder<String?>(
+          valueListenable: notifier,
+          builder: (context, currentValue, child) {
+            final iconName = currentValue ?? '';
+            final icon =
+                AvailableIcons.fromName(iconName)?.iconData ??
+                Icons.broken_image;
+            return Icon(icon);
+          },
+        );
+      },
+  exampleData: [
+    () => '''
+      [
+        {
+          "id": "root",
+          "component": {
+            "Icon": {
+              "name": {
+                "literalString": "add"
+              }
+            }
+          }
+        }
+      ]
+    ''',
+  ],
+);

--- a/packages/flutter_genui/lib/src/model/a2ui_schemas.dart
+++ b/packages/flutter_genui/lib/src/model/a2ui_schemas.dart
@@ -14,13 +14,20 @@ class A2uiSchemas {
   /// data-bound path to a string in the DataModel. If both path and
   /// literal are provided, the value at the path will be initialized
   /// with the literal.
-  static Schema stringReference({String? description}) => S.object(
+  ///
+  /// If `enumValues` are provided, the string value (either literal or at the
+  /// path) must be one of the values in the enum.
+  static Schema stringReference({
+    String? description,
+    List<String>? enumValues,
+  }) => S.object(
     description: description,
     properties: {
       'path': S.string(
         description: 'A relative or absolute path in the data model.',
+        enumValues: enumValues,
       ),
-      'literalString': S.string(),
+      'literalString': S.string(enumValues: enumValues),
     },
   );
 

--- a/packages/flutter_genui/test/catalog/core_widgets/icon_test.dart
+++ b/packages/flutter_genui/test/catalog/core_widgets/icon_test.dart
@@ -1,0 +1,88 @@
+// Copyright 2025 The Flutter Authors.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter/material.dart';
+import 'package:flutter_genui/flutter_genui.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  testWidgets('Icon widget renders with literal string', (
+    WidgetTester tester,
+  ) async {
+    final manager = GenUiManager(
+      catalog: Catalog([CoreCatalogItems.icon]),
+      configuration: const GenUiConfiguration(),
+    );
+    const surfaceId = 'testSurface';
+    final components = [
+      const Component(
+        id: 'icon',
+        componentProperties: {
+          'Icon': {
+            'name': {'literalString': 'add'},
+          },
+        },
+      ),
+    ];
+    manager.handleMessage(
+      SurfaceUpdate(surfaceId: surfaceId, components: components),
+    );
+    manager.handleMessage(
+      const BeginRendering(surfaceId: surfaceId, root: 'icon'),
+    );
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: GenUiSurface(host: manager, surfaceId: surfaceId),
+        ),
+      ),
+    );
+
+    expect(find.byIcon(Icons.add), findsOneWidget);
+  });
+
+  testWidgets('Icon widget renders with data binding', (
+    WidgetTester tester,
+  ) async {
+    final manager = GenUiManager(
+      catalog: Catalog([CoreCatalogItems.icon]),
+      configuration: const GenUiConfiguration(),
+    );
+    const surfaceId = 'testSurface';
+    final components = [
+      const Component(
+        id: 'icon',
+        componentProperties: {
+          'Icon': {
+            'name': {'path': '/iconName'},
+          },
+        },
+      ),
+    ];
+    manager.handleMessage(
+      SurfaceUpdate(surfaceId: surfaceId, components: components),
+    );
+    manager.handleMessage(
+      const DataModelUpdate(
+        surfaceId: 'testSurface',
+        path: '/iconName',
+        contents: 'close',
+      ),
+    );
+    manager.handleMessage(
+      const BeginRendering(surfaceId: surfaceId, root: 'icon'),
+    );
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: GenUiSurface(host: manager, surfaceId: surfaceId),
+        ),
+      ),
+    );
+
+    expect(find.byIcon(Icons.close), findsOneWidget);
+  });
+}


### PR DESCRIPTION
# Description

Adds support for the `Icon` component. Only added a limited set of icons, to keep the description short, and to keep from overwhelming the context with them.  There are 8825 different icons, so it would be a lot...

This PR currently also contains the contents of the https://github.com/flutter/genui/pull/473 PR, which will be rebased away once that lands.