### PR TITLE
Make CheckBox clickable in Catalog Gallery

### DIFF
--- a/packages/flutter_genui/lib/src/catalog/core_widgets/check_box.dart
+++ b/packages/flutter_genui/lib/src/catalog/core_widgets/check_box.dart
@@ -84,6 +84,7 @@ final checkBox = CatalogItem(
                 "literalString": "Check me"
               },
               "value": {
+                "path": "/myValue",
                 "literalBoolean": true
               }
             }


### PR DESCRIPTION
# Description

The `CheckBox` component in the Catalog Gallery was not clickable because the `CheckBox` value in the example had no "path" for the `DataContext` to update.

I fixed that in this PR by adding a "path" to the value.

 | Before | After |
|--------|--------|
| <video src="https://github.com/user-attachments/assets/4fbeb447-1621-4968-9d87-8fa110a8623d"/> | <video src="https://github.com/user-attachments/assets/584d6359-4a33-4eb8-9160-9fa10242a668"/> |









Fixes #403 
Part of #448

## Pre-launch Checklist

- [x] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [x] I signed the [CLA].
- [x] I read the [Contributors Guide].
- [ ] I have added sample code updates to the [changelog].
- [ ] I updated/added relevant documentation (doc comments with `///`).

If you need help, consider asking for advice on the #hackers-devrel channel on [Discord].

<!-- Links -->

[Flutter Style Guide]: https://github.com/flutter/flutter/blob/master/docs/contributing/Style-guide-for-Flutter-repo.md
[CLA]: https://cla.developers.google.com/
[Discord]: https://github.com/flutter/flutter/blob/master/docs/contributing/Chat.md
[Contributors Guide]: https://github.com/flutter/samples/blob/main/CONTRIBUTING.md
[changelog]: ../CHANGELOG.md