### PR TITLE
Make Modal example work

### DIFF
--- a/packages/flutter_genui/lib/src/catalog/core_widgets/modal.dart
+++ b/packages/flutter_genui/lib/src/catalog/core_widgets/modal.dart
@@ -77,7 +77,7 @@ final modal = CatalogItem(
                   {
                     "key": "modalId",
                     "value": {
-                      "literalString": "modal"
+                      "literalString": "root"
                     }
                   }
                 ]


### PR DESCRIPTION
# Description

The `Modal` component example wasn't working because the "showModal" action was using a modal ID of "modal" instead of the correct ID "root". 

Fixed now by correcting the modal ID. 

 | Before | After |
|--------|--------|
| <video src="https://github.com/user-attachments/assets/e05bed1c-c916-4683-ad95-1f159d9fd306"/> | <video src="https://github.com/user-attachments/assets/c13702a5-b94a-4021-ba5a-34c03505d14d"/> |

Part of #448

## Pre-launch Checklist

- [x] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [x] I signed the [CLA].
- [x] I read the [Contributors Guide].
- [ ] I have added sample code updates to the [changelog].
- [ ] I updated/added relevant documentation (doc comments with `///`).

If you need help, consider asking for advice on the #hackers-devrel channel on [Discord].

<!-- Links -->

[Flutter Style Guide]: https://github.com/flutter/flutter/blob/master/docs/contributing/Style-guide-for-Flutter-repo.md
[CLA]: https://cla.developers.google.com/
[Discord]: https://github.com/flutter/flutter/blob/master/docs/contributing/Chat.md
[Contributors Guide]: https://github.com/flutter/samples/blob/main/CONTRIBUTING.md
[changelog]: ../CHANGELOG.md
