### PR TITLE
Fix error being reported twice from Firebase AI content generator

### DIFF
--- a/packages/genui_firebase_ai/lib/src/firebase_ai_content_generator.dart
+++ b/packages/genui_firebase_ai/lib/src/firebase_ai_content_generator.dart
@@ -412,16 +412,10 @@ With functions:
       );
       final inferenceStartTime = DateTime.now();
       GenerateContentResponse response;
-      try {
-        response = await model.generateContent(mutableContent);
-        genUiLogger.finest(
-          'Raw model response: ${_responseToString(response)}',
-        );
-      } catch (e, st) {
-        genUiLogger.severe('Error from model.generateContent', e, st);
-        _errorController.add(ContentGeneratorError(e, st));
-        rethrow;
-      }
+
+      response = await model.generateContent(mutableContent);
+      genUiLogger.finest('Raw model response: ${_responseToString(response)}');
+
       final Duration elapsed = DateTime.now().difference(inferenceStartTime);
 
       if (response.usageMetadata != null) {


### PR DESCRIPTION
I have been seeing the same error appear twice in chat messages from the agent.

This is caused by us catching an error, printing and reporting to the error stream, then rethrowing and doing exactly the same later.

This just removes the redundant inner error reporting.

### Example UI

<img width="848" height="1232" alt="Screenshot 2025-11-17 at 2 05 41 PM" src="https://github.com/user-attachments/assets/a4964736-e1c0-47af-b3c6-7d803bc17fd3" />

### Example logs
```
flutter: [SEVERE] 2025-11-17 13:58:52.320505: Error from model.generateContent
flutter:   Error: The specified schema produces a constraint that has too many states for serving. Typical causes of this error are schemas with lots of text (for example, very long property or enum names), schemas with long array length limits (especially when nested), or schemas using complex value matchers (for example, integers or numbers with minimum/maximum bounds or strings with complex formats like date-time)
flutter:   Stack trace:
#0      DeveloperSerialization.parseGenerateContentResponse (package:firebase_ai/src/developer/api.dart:70:56)
<asynchronous suspension>
#1      FirebaseAiContentGenerator._generate (package:genui_firebase_ai/src/firebase_ai_content_generator.dart:416:20)
<asynchronous suspension>
#2      FirebaseAiContentGenerator.sendRequest (package:genui_firebase_ai/src/firebase_ai_content_generator.dart:118:32)
<asynchronous suspension>
#3      _TravelPlannerPageState._triggerInference (package:travel_app/src/travel_planner_page.dart:122:5)
<asynchronous suspension>

flutter: [SEVERE] 2025-11-17 13:58:52.321185: Error generating content
flutter:   Error: The specified schema produces a constraint that has too many states for serving. Typical causes of this error are schemas with lots of text (for example, very long property or enum names), schemas with long array length limits (especially when nested), or schemas using complex value matchers (for example, integers or numbers with minimum/maximum bounds or strings with complex formats like date-time)
flutter:   Stack trace:
#0      DeveloperSerialization.parseGenerateContentResponse (package:firebase_ai/src/developer/api.dart:70:56)
<asynchronous suspension>
#1      FirebaseAiContentGenerator._generate (package:genui_firebase_ai/src/firebase_ai_content_generator.dart:416:20)
<asynchronous suspension>
#2      FirebaseAiContentGenerator.sendRequest (package:genui_firebase_ai/src/firebase_ai_content_generator.dart:118:32)
<asynchronous suspension>
#3      _TravelPlannerPageState._triggerInference (package:travel_app/src/travel_planner_page.dart:122:5)
<asynchronous suspension>

flutter: _handleError #0      GenUiConversation._handleError (package:genui/src/conversation/gen_ui_conversation.dart:165:38)
#1      _RootZone.runUnaryGuarded (dart:async/zone.dart:1778:10)
#2      _BufferingStreamSubscription._sendData (dart:async/stream_impl.dart:381:11)
#3      _DelayedData.perform (dart:async/stream_impl.dart:573:14)
#4      _PendingEvents.handleNext (dart:async/stream_impl.dart:678:11)
#5      _PendingEvents.schedule.<anonymous closure> (dart:async/stream_impl.dart:649:7)
#6      _microtaskLoop (dart:async/schedule_microtask.dart:40:35)
#7      _startMicrotaskLoop (dart:async/schedule_microtask.dart:49:5)

flutter: _handleError #0      GenUiConversation._handleError (package:genui/src/conversation/gen_ui_conversation.dart:165:38)
#1      _RootZone.runUnaryGuarded (dart:async/zone.dart:1778:10)
#2      _BufferingStreamSubscription._sendData (dart:async/stream_impl.dart:381:11)
#3      _DelayedData.perform (dart:async/stream_impl.dart:573:14)
#4      _PendingEvents.handleNext (dart:async/stream_impl.dart:678:11)
#5      _PendingEvents.schedule.<anonymous closure> (dart:async/stream_impl.dart:649:7)
#6      _microtaskLoop (dart:async/schedule_microtask.dart:40:35)
#7      _startMicrotaskLoop (dart:async/schedule_microtask.dart:49:5)
```
