### PR TITLE
Fix basic chat app through prompt engineering

### DIFF
--- a/examples/simple_chat/lib/main.dart
+++ b/examples/simple_chat/lib/main.dart
@@ -89,7 +89,7 @@ IMPORTANT: When you generate UI in a response, you MUST always create
 a new surface with a unique `surfaceId`. Do NOT reuse or update
 existing `surfaceId`s. Each UI response must be in its own new surface.
 
-'${GenUiPromptFragments.basicChat}''';
+${GenUiPromptFragments.basicChat}''';
 
     // Create the appropriate content generator based on configuration
     final ContentGenerator contentGenerator = switch (aiBackend) {

--- a/packages/genui/lib/src/model/a2ui_schemas.dart
+++ b/packages/genui/lib/src/model/a2ui_schemas.dart
@@ -85,7 +85,7 @@ class A2uiSchemas {
       'name': S.string(),
       'context': S.list(
         description:
-            'A list of name-value pairs to be sent with the action to include'
+            'A list of name-value pairs to be sent with the action to include '
             'data associated with the action, e.g. values that are submitted.',
         items: S.object(
           properties: {
@@ -95,8 +95,8 @@ class A2uiSchemas {
                 'path': S.string(
                   description:
                       'A path in the data model which should be bound to an '
-                      'input element, e.g. a string reference for a text field,'
-                      'or number reference for a slider.',
+                      'input element, e.g. a string reference for a text '
+                      'field, or number reference for a slider.',
                 ),
                 'literalString': S.string(
                   description: 'A literal string relevant to the action',


### PR DESCRIPTION
This fixes two issues:
- Basic chat would constantly update a single surface rather than creating new surfaces, which was confusing.
- Basic chat would use Data model paths incorrectly, e.g. refer to non-existant data model paths in the submit button context. This made the submit actions break.

With this change, the basic chat is sort of usable now.

<img width="899" height="1479" alt="Screenshot 2025-11-17 at 3 40 14 PM" src="https://github.com/user-attachments/assets/69520b8a-38aa-4727-99fd-ab8bd9fa2ecc" />
