### PR TITLE
Make genui_google_generative_ai package publishable

### DIFF
--- a/packages/genui_google_generative_ai/pubspec.yaml
+++ b/packages/genui_google_generative_ai/pubspec.yaml
@@ -8,7 +8,6 @@ version: 0.5.1
 homepage: https://github.com/flutter/genui/tree/main/packages/genui_google_generative_ai
 license: BSD-3-Clause
 issue_tracker: https://github.com/flutter/genui/issues
-publish_to: none
 
 environment:
   sdk: ">=3.9.2 <4.0.0"


### PR DESCRIPTION
# Description

Just removing publish_to: none from the pubspec so it can be published.

