### PR TITLE
Update readme to highlight alternative content generators

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ based on a widget catalog from the developers' project.
 ## Connecting to an AI Agent
 
 The `genui` framework uses a `ContentGenerator` to communicate with a generative AI model,
-allowing `genui` to be backend-agnostic. You can choose the implementation that best fits
+allowing `genui` to be backend agnostic. You can choose the implementation that best fits
 your needs, whether it's `FirebaseAiContentGenerator` for production apps,
 `GoogleGenerativeAiContentGenerator` for rapid prototyping, or `A2uiContentGenerator` for
 custom agent servers.


### PR DESCRIPTION
This PR updates the top-level README.md to better inform developers about the different ContentGenerator implementations available for connecting the GenUI framework to an AI backend.

Previously, the README only mentioned the genui_firebase_ai package, which could lead developers to believe that Firebase AI Logic is the only supported backend. This change clarifies that there are multiple options for different use cases.

Changes:

   - Adds a new "Connecting to an AI Agent" section: This briefly introduces the
     ContentGenerator concept, which allows genui to be backend-agnostic.
   - Updates the main "Packages" table: The table now includes
     genui_google_generative_ai and genui_a2ui and provides clear, concise
     descriptions for each package, highlighting the specific ContentGenerator it
     contains and its primary use case (e.g., production, prototyping, custom
     servers).

This makes it easier for developers to quickly understand and choose the right package for their project.

Fixes https://github.com/flutter/genui/issues/522