### PR TITLE
Update A2UI extension name to https://a2ui.org/a2a-extension/a2ui/v0.8

### DIFF
--- a/packages/genui_a2ui/lib/src/a2ui_agent_connector.dart
+++ b/packages/genui_a2ui/lib/src/a2ui_agent_connector.dart
@@ -130,7 +130,7 @@ class A2uiAgentConnector {
     }
 
     final payload = A2AMessageSendParams()..message = message;
-    payload.extensions = ['https://a2ui.org/a2a-extension/v0.8'];
+    payload.extensions = ['https://a2ui.org/a2a-extension/a2ui/v0.8'];
 
     _log.info('--- OUTGOING REQUEST ---');
     _log.info('URL: ${url.toString()}');
@@ -232,7 +232,7 @@ class A2uiAgentConnector {
       ..referenceTaskIds = [taskId!];
 
     final payload = A2AMessageSendParams()..message = message;
-    payload.extensions = ['https://a2ui.org/a2a-extension/v0.8'];
+    payload.extensions = ['https://a2ui.org/a2a-extension/a2ui/v0.8'];
 
     try {
       await client.sendMessage(payload);


### PR DESCRIPTION
This needs to match the name used in the agent examples for them to work together.

I will update the name on the agent side separately, because it's currently at v0.1.