### PR TITLE
chore(lints): `remove specify_nonobvious_local_variable_types` rule

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -40,5 +40,4 @@ linter:
     - unreachable_from_main
 
     - omit_obvious_local_variable_types
-    - specify_nonobvious_local_variable_types
     - specify_nonobvious_property_types


### PR DESCRIPTION
## Description

`specify_nonobvious_local_variable_types` asks us to write/read explicit type declarations for lines like

``` dart
final localizations = MaterialLocalizations.of(context);
```

and

```dart
final date = DateTime.parse(value);
```

In these scenarios, I find the variable data type to be quite obvious. Since this rule isn't programmable to not trip in these scenarios, I propose we remove it and trust code authors to use or omit types at their discretion.

## Pre-launch Checklist

- [x] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [x] I signed the [CLA].
- [x] I read the [Contributors Guide].
- [x] I have added sample code updates to the [changelog].
- [x] I updated/added relevant documentation (doc comments with `///`).

If you need help, consider asking for advice on the #hackers-devrel channel on [Discord].

<!-- Links -->

[Flutter Style Guide]: https://github.com/flutter/flutter/blob/master/docs/contributing/Style-guide-for-Flutter-repo.md
[CLA]: https://cla.developers.google.com/
[Discord]: https://github.com/flutter/flutter/blob/master/docs/contributing/Chat.md
[Contributors Guide]: https://github.com/flutter/samples/blob/main/CONTRIBUTING.md
[changelog]: ../CHANGELOG.md
