### PR TITLE
Improve error handling for catalog example loading

### DIFF
--- a/packages/genui/lib/src/development_utilities/catalog_view.dart
+++ b/packages/genui/lib/src/development_utilities/catalog_view.dart
@@ -67,30 +67,39 @@ class _DebugCatalogViewState extends State<DebugCatalogView> {
         final surfaceId = '${item.name}$indexPart';
 
         final String exampleJsonString = exampleBuilder();
-        final exampleData = jsonDecode(exampleJsonString) as List<Object?>;
 
-        final List<Component> components = exampleData
-            .map((e) => Component.fromJson(e as JsonMap))
-            .toList();
+        try {
+          final exampleData = jsonDecode(exampleJsonString) as List<Object?>;
 
-        Component? rootComponent;
-        rootComponent = components.firstWhereOrNull((c) => c.id == 'root');
+          final List<Component> components = exampleData
+              .map((e) => Component.fromJson(e as JsonMap))
+              .toList();
 
-        if (rootComponent == null) {
-          debugPrint(
-            'Skipping example for ${item.name} because it is missing a root '
-            'component.',
+          Component? rootComponent;
+          rootComponent = components.firstWhereOrNull((c) => c.id == 'root');
+
+          if (rootComponent == null) {
+            debugPrint(
+              'Skipping example for ${item.name} because it is missing a root '
+              'component.',
+            );
+            continue;
+          }
+
+          _a2uiMessageProcessor.handleMessage(
+            SurfaceUpdate(surfaceId: surfaceId, components: components),
           );
-          continue;
+          _a2uiMessageProcessor.handleMessage(
+            BeginRendering(surfaceId: surfaceId, root: rootComponent.id),
+          );
+          surfaceIds.add(surfaceId);
+        } catch (e, s) {
+          debugPrint('Failed to load example for "${item.name}":\n$e\n$s');
+          throw Exception(
+            'Failed to load example for "${item.name}". Check logs for '
+            'details.',
+          );
         }
-
-        _a2uiMessageProcessor.handleMessage(
-          SurfaceUpdate(surfaceId: surfaceId, components: components),
-        );
-        _a2uiMessageProcessor.handleMessage(
-          BeginRendering(surfaceId: surfaceId, root: rootComponent.id),
-        );
-        surfaceIds.add(surfaceId);
       }
     }
   }


### PR DESCRIPTION
# Description

Wraps the example data parsing and component creation in a try-catch block to capture and rethrow errors with additional context (the item name). This makes it easier to identify which catalog item has invalid example data.

- Before: 
<img width="886" height="732" alt="8WpDcojbwa82k4a" src="https://github.com/user-attachments/assets/4d081e8f-bd19-421c-8b76-3a199b2b3b4b" />

- After: 
<img width="1326" height="843" alt="4nvrGgbbRzVuPYD" src="https://github.com/user-attachments/assets/940839c9-9b91-4bd1-99fe-ba5585f21898" />


## Pre-launch Checklist

- [ ] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [ ] I signed the [CLA].
- [ ] I read the [Contributors Guide].
- [ ] I have added sample code updates to the [changelog].
- [ ] I updated/added relevant documentation (doc comments with `///`).

If you need help, consider asking for advice on the #hackers-devrel channel on [Discord].

<!-- Links -->

[Flutter Style Guide]: https://github.com/flutter/flutter/blob/master/docs/contributing/Style-guide-for-Flutter-repo.md
[CLA]: https://cla.developers.google.com/
[Discord]: https://github.com/flutter/flutter/blob/master/docs/contributing/Chat.md
[Contributors Guide]: https://github.com/flutter/samples/blob/main/CONTRIBUTING.md
[changelog]: ../CHANGELOG.md
