### PR TITLE
Make `ContentGeneratorError` be an `Exception`

### DIFF
--- a/packages/genui/lib/src/content_generator.dart
+++ b/packages/genui/lib/src/content_generator.dart
@@ -11,15 +11,15 @@ import 'model/a2ui_message.dart';
 import 'model/chat_message.dart';
 
 /// An error produced by a [ContentGenerator].
-final class ContentGeneratorError {
+final class ContentGeneratorError implements Exception {
   /// The error that occurred.
   final Object error;
 
   /// The stack trace of the error.
-  final StackTrace stackTrace;
+  final StackTrace? stackTrace;
 
   /// Creates a [ContentGeneratorError].
-  const ContentGeneratorError(this.error, this.stackTrace);
+  const ContentGeneratorError(this.error, [this.stackTrace]);
 }
 
 /// An abstract interface for a content generator.


### PR DESCRIPTION
# Description

A simple change so that throwing a `ContentGeneratorError` won't generate a warning if the `only_throw_errors` lint is enabled.

Also makes the stack trace optional, since there might not always be one available.