### PR TITLE
Fix small automation warning

### DIFF
--- a/.github/workflows/flutter_packages.yaml
+++ b/.github/workflows/flutter_packages.yaml
@@ -95,7 +95,7 @@ jobs:
   analyze_and_test:
     needs: matrix
     # Only run if the matrix job has produced a non-empty matrix.
-    if: github.repository == 'flutter/genui' && ${{ needs.matrix.outputs.matrix != '[]' }}
+    if: github.repository == 'flutter/genui' && needs.matrix.outputs.matrix != '[]'
     name: ${{ matrix.package.name }} (${{ matrix.flutter_version }})
     runs-on: ${{ matrix.os }}
     strategy:


### PR DESCRIPTION
# Description

Fixes a warning (and bug) in the CI automation.

This fixes the warning:

"Conditional expression contains literal text outside replacement tokens. This will cause the expression to always evaluate to truthy." 

on line 98.