### PR TITLE
Fix pub dependabot

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -9,11 +9,8 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
-    #  Don't auto-submit github actions updates
-    # labels:
-    #   - "autosubmit"
   - package-ecosystem: "pub"
-    directory: "packages/genui_client"
+    directory: "/"
     schedule:
       interval: "daily"
     labels:


### PR DESCRIPTION
# Description

This updates the dependabot pub entry so that it will check the pubspec file for updates, and perform them automatically if the tests pass.

This will now update all of the dependencies in the workspace. (according to https://github.com/dart-lang/pub/issues/4290)