### PR TITLE
feat: add current date and time to system instructions in the sample travel app

### DIFF
--- a/examples/travel_app/lib/src/travel_planner_page.dart
+++ b/examples/travel_app/lib/src/travel_planner_page.dart
@@ -246,6 +246,8 @@ String? _imagesJson;
 
 final prompt =
     '''
+Today is ${DateTime.timestamp()}
+
 # Instructions
 
 You are a helpful travel agent assistant that communicates by creating and


### PR DESCRIPTION
# Description

Add current date and time to the system instructions in the sample travel app.

This provides the LLM with relevant context when processing user messages with relative date / time information such "_Show me available options for a family trip to London **next Easter**_".

Noticed this when running the app and the LLM was returning dates set in 2024.

## Pre-launch Checklist

- [x] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [x] I signed the [CLA].
- [x] I read the [Contributors Guide].
- [ ] I have added sample code updates to the [changelog].
- [ ] I updated/added relevant documentation (doc comments with `///`).

If you need help, consider asking for advice on the #hackers-devrel channel on [Discord].

<!-- Links -->

[Flutter Style Guide]: https://github.com/flutter/flutter/blob/master/docs/contributing/Style-guide-for-Flutter-repo.md
[CLA]: https://cla.developers.google.com/
[Discord]: https://github.com/flutter/flutter/blob/master/docs/contributing/Chat.md
[Contributors Guide]: https://github.com/flutter/samples/blob/main/CONTRIBUTING.md
[changelog]: ../CHANGELOG.md
