### PR TITLE
feat(a2ui_message): make toJson compatible with fromJson

### DIFF
--- a/packages/genui/lib/src/model/a2ui_message.dart
+++ b/packages/genui/lib/src/model/a2ui_message.dart
@@ -121,6 +121,9 @@ sealed class A2uiMessage {
       ],
     );
   }
+
+  /// Converts this message to a JSON map.
+  Map<String, dynamic> toJson();
 }
 
 /// An A2UI message that signals the client to create and show a new surface.
@@ -155,13 +158,15 @@ final class CreateSurface extends A2uiMessage {
   /// If true, the client sends the full data model in A2A metadata.
   final bool sendDataModel;
 
-  /// Converts this message to a JSON map.
+  @override
   Map<String, dynamic> toJson() => {
     'version': 'v0.9',
-    surfaceIdKey: surfaceId,
-    'catalogId': catalogId,
-    'theme': ?theme,
-    'sendDataModel': sendDataModel,
+    'createSurface': {
+      surfaceIdKey: surfaceId,
+      'catalogId': catalogId,
+      'theme': theme,
+      'sendDataModel': sendDataModel,
+    },
   };
 }
 
@@ -187,10 +192,16 @@ final class UpdateComponents extends A2uiMessage {
   final List<Component> components;
 
   /// Converts this message to a JSON map.
+  ///
+  /// The result is compatible with [A2uiMessage.fromJson] for round-trip
+  /// serialization (e.g. when saving messages locally).
+  @override
   Map<String, dynamic> toJson() => {
     'version': 'v0.9',
-    surfaceIdKey: surfaceId,
-    'components': components.map((c) => c.toJson()).toList(),
+    'updateComponents': {
+      surfaceIdKey: surfaceId,
+      'components': components.map((c) => c.toJson()).toList(),
+    },
   };
 }
 
@@ -224,12 +235,14 @@ final class UpdateDataModel extends A2uiMessage {
   /// key at the path.
   final Object? value;
 
-  /// Converts this message to a JSON map.
+  @override
   Map<String, dynamic> toJson() => {
     'version': 'v0.9',
-    surfaceIdKey: surfaceId,
-    'path': path.toString(),
-    'value': ?value,
+    'updateDataModel': {
+      surfaceIdKey: surfaceId,
+      'path': path.toString(),
+      'value': value,
+    },
   };
 }
 
@@ -246,6 +259,9 @@ final class DeleteSurface extends A2uiMessage {
   /// The ID of the surface that this message applies to.
   final String surfaceId;
 
-  /// Converts this message to a JSON map.
-  Map<String, dynamic> toJson() => {'version': 'v0.9', surfaceIdKey: surfaceId};
+  @override
+  Map<String, dynamic> toJson() => {
+    'version': 'v0.9',
+    'deleteSurface': {surfaceIdKey: surfaceId},
+  };
 }

--- a/packages/genui/lib/test/validation.dart
+++ b/packages/genui/lib/test/validation.dart
@@ -81,8 +81,10 @@ Future<List<ExampleValidationError>> validateCatalogItemExamples(
       components: components,
     );
 
+    final payload =
+        surfaceUpdate.toJson()['updateComponents'] as Map<String, dynamic>;
     final List<ValidationError> validationErrors = await schema.validate(
-      surfaceUpdate.toJson(),
+      payload,
     );
     if (validationErrors.isNotEmpty) {
       errors.add(

--- a/packages/genui/test/model/a2ui_message_test.dart
+++ b/packages/genui/test/model/a2ui_message_test.dart
@@ -105,6 +105,66 @@ void main() {
       expect(message.toJson(), containsPair('version', 'v0.9'));
     });
 
+    test('CreateSurface round-trip: toJson then fromJson', () {
+      const message = CreateSurface(
+        surfaceId: 's1',
+        catalogId: 'c1',
+        theme: {'color': 'blue'},
+        sendDataModel: true,
+      );
+      final decoded = A2uiMessage.fromJson(
+        Map<String, dynamic>.from(message.toJson()),
+      );
+      expect(decoded, isA<CreateSurface>());
+      final create = decoded as CreateSurface;
+      expect(create.surfaceId, message.surfaceId);
+      expect(create.catalogId, message.catalogId);
+      expect(create.theme, message.theme);
+      expect(create.sendDataModel, message.sendDataModel);
+    });
+
+    test('UpdateComponents round-trip: toJson then fromJson', () {
+      const message = UpdateComponents(
+        surfaceId: 's1',
+        components: [
+          Component(id: 'c1', type: 'Text', properties: {'text': 'Hi'}),
+        ],
+      );
+      final decoded = A2uiMessage.fromJson(
+        Map<String, dynamic>.from(message.toJson()),
+      );
+      expect(decoded, isA<UpdateComponents>());
+      final update = decoded as UpdateComponents;
+      expect(update.surfaceId, message.surfaceId);
+      expect(update.components.length, message.components.length);
+      expect(update.components.first.id, message.components.first.id);
+    });
+
+    test('UpdateDataModel round-trip: toJson then fromJson', () {
+      final message = UpdateDataModel(
+        surfaceId: 's1',
+        path: DataPath('/user/name'),
+        value: 'Alice',
+      );
+      final decoded = A2uiMessage.fromJson(
+        Map<String, dynamic>.from(message.toJson()),
+      );
+      expect(decoded, isA<UpdateDataModel>());
+      final update = decoded as UpdateDataModel;
+      expect(update.surfaceId, message.surfaceId);
+      expect(update.path, message.path);
+      expect(update.value, message.value);
+    });
+
+    test('DeleteSurface round-trip: toJson then fromJson', () {
+      const message = DeleteSurface(surfaceId: 's1');
+      final decoded = A2uiMessage.fromJson(
+        Map<String, dynamic>.from(message.toJson()),
+      );
+      expect(decoded, isA<DeleteSurface>());
+      expect((decoded as DeleteSurface).surfaceId, message.surfaceId);
+    });
+
     test('fromJson throws on unknown message type', () {
       final json = <String, Object>{'version': 'v0.9', 'unknown': {}};
       expect(

--- a/packages/genui/test/test_infra/validation_test_utils.dart
+++ b/packages/genui/test/test_infra/validation_test_utils.dart
@@ -53,8 +53,11 @@ void validateCatalogExamples(
             components: components,
           );
 
+          final payload =
+              surfaceUpdate.toJson()['updateComponents']
+                  as Map<String, dynamic>;
           final List<ValidationError> validationErrors = await schema.validate(
-            surfaceUpdate.toJson(),
+            payload,
           );
           expect(validationErrors, isEmpty);
         });


### PR DESCRIPTION
# Description

- Each `A2uiMessage` subclass’s `toJson()` now returns the wrapped envelope (version + one of createSurface / updateComponents / updateDataModel / deleteSurface) instead of a flat payload.
- This matches the shape that `A2uiMessage.fromJson()` expects, so round-trip works.

**Why**

- Use case: Persisting messages locally (e.g. saving conversation history) and reloading with `A2uiMessage.fromJson(saved)`.
- Previously, `fromJson(message.toJson())` failed because the root map had no action key.
- Before: To save a message you had to switch on each type (`CreateSurface`, `UpdateComponents`, etc.) and build JSON per variant. 
  - Now: You can call `message.toJson()` on any `A2uiMessage` and save without type checks.


------ 

- `CreateSurface`, `UpdateComponents`, `UpdateDataModel`, and `DeleteSurface` now put their payload under the corresponding key. 

- Round-trip tests were added

## Pre-launch Checklist

- [x] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [x] I signed the [CLA].
- [x] I read the [Contributors Guide].
- [ ] I have added sample code updates to the [changelog].
- [ ] I updated/added relevant documentation (doc comments with `///`).

If you need help, consider asking for advice on the #hackers-devrel channel on [Discord].

<!-- Links -->

[Flutter Style Guide]: https://github.com/flutter/flutter/blob/master/docs/contributing/Style-guide-for-Flutter-repo.md
[CLA]: https://cla.developers.google.com/
[Discord]: https://github.com/flutter/flutter/blob/master/docs/contributing/Chat.md
[Contributors Guide]: https://github.com/flutter/samples/blob/main/CONTRIBUTING.md
[changelog]: ../CHANGELOG.md
