### PR TITLE
fix: prompt builder misleading LLM to return free text amongst A2UI messages

### DIFF
--- a/packages/genui/lib/src/facade/prompt_builder.dart
+++ b/packages/genui/lib/src/facade/prompt_builder.dart
@@ -311,7 +311,7 @@ To update an existing UI:
       _fenced('''
 When constructing UI, you must output a VALID A2UI JSON object representing one of the A2UI message types ($_operationsFormatted).
 - You can treat the A2UI schema as a specification for the JSON you typically output.
-- You may include a brief conversational explanation before or after the JSON block if it helps the user, but the JSON block must be valid and complete.
+- The JSON block must be valid and complete.
 - Ensure your JSON is fenced with ```json and ```.
 ''', sectionName: 'OUTPUT FORMAT'),
     );

--- a/packages/genui/test/facade/prompt_builder_test.golden/all_operations_with_dataModel_false.txt
+++ b/packages/genui/test/facade/prompt_builder_test.golden/all_operations_with_dataModel_false.txt
@@ -119,7 +119,7 @@ To update an existing UI:
 -----OUTPUT_FORMAT_START-----
 When constructing UI, you must output a VALID A2UI JSON object representing one of the A2UI message types (`createSurface`, `updateComponents`, `deleteSurface`).
 - You can treat the A2UI schema as a specification for the JSON you typically output.
-- You may include a brief conversational explanation before or after the JSON block if it helps the user, but the JSON block must be valid and complete.
+- The JSON block must be valid and complete.
 - Ensure your JSON is fenced with ```json and ```.
 -----OUTPUT_FORMAT_END-----
 

--- a/packages/genui/test/facade/prompt_builder_test.golden/all_operations_with_dataModel_true.txt
+++ b/packages/genui/test/facade/prompt_builder_test.golden/all_operations_with_dataModel_true.txt
@@ -121,7 +121,7 @@ To update an existing UI:
 -----OUTPUT_FORMAT_START-----
 When constructing UI, you must output a VALID A2UI JSON object representing one of the A2UI message types (`createSurface`, `updateComponents`, `deleteSurface`, `updateDataModel`).
 - You can treat the A2UI schema as a specification for the JSON you typically output.
-- You may include a brief conversational explanation before or after the JSON block if it helps the user, but the JSON block must be valid and complete.
+- The JSON block must be valid and complete.
 - Ensure your JSON is fenced with ```json and ```.
 -----OUTPUT_FORMAT_END-----
 

--- a/packages/genui/test/facade/prompt_builder_test.golden/create_and_update_with_dataModel_false.txt
+++ b/packages/genui/test/facade/prompt_builder_test.golden/create_and_update_with_dataModel_false.txt
@@ -117,7 +117,7 @@ To update an existing UI:
 -----OUTPUT_FORMAT_START-----
 When constructing UI, you must output a VALID A2UI JSON object representing one of the A2UI message types (`createSurface`, `updateComponents`).
 - You can treat the A2UI schema as a specification for the JSON you typically output.
-- You may include a brief conversational explanation before or after the JSON block if it helps the user, but the JSON block must be valid and complete.
+- The JSON block must be valid and complete.
 - Ensure your JSON is fenced with ```json and ```.
 -----OUTPUT_FORMAT_END-----
 

--- a/packages/genui/test/facade/prompt_builder_test.golden/create_and_update_with_dataModel_true.txt
+++ b/packages/genui/test/facade/prompt_builder_test.golden/create_and_update_with_dataModel_true.txt
@@ -119,7 +119,7 @@ To update an existing UI:
 -----OUTPUT_FORMAT_START-----
 When constructing UI, you must output a VALID A2UI JSON object representing one of the A2UI message types (`createSurface`, `updateComponents`, `updateDataModel`).
 - You can treat the A2UI schema as a specification for the JSON you typically output.
-- You may include a brief conversational explanation before or after the JSON block if it helps the user, but the JSON block must be valid and complete.
+- The JSON block must be valid and complete.
 - Ensure your JSON is fenced with ```json and ```.
 -----OUTPUT_FORMAT_END-----
 

--- a/packages/genui/test/facade/prompt_builder_test.golden/create_only_with_dataModel_false.txt
+++ b/packages/genui/test/facade/prompt_builder_test.golden/create_only_with_dataModel_false.txt
@@ -116,7 +116,7 @@ IMPORTANT: DO NOT update or modify surfaces created in previous turns. If the UI
 -----OUTPUT_FORMAT_START-----
 When constructing UI, you must output a VALID A2UI JSON object representing one of the A2UI message types (`createSurface`, `updateComponents`).
 - You can treat the A2UI schema as a specification for the JSON you typically output.
-- You may include a brief conversational explanation before or after the JSON block if it helps the user, but the JSON block must be valid and complete.
+- The JSON block must be valid and complete.
 - Ensure your JSON is fenced with ```json and ```.
 -----OUTPUT_FORMAT_END-----
 

--- a/packages/genui/test/facade/prompt_builder_test.golden/create_only_with_dataModel_true.txt
+++ b/packages/genui/test/facade/prompt_builder_test.golden/create_only_with_dataModel_true.txt
@@ -118,7 +118,7 @@ IMPORTANT: DO NOT update or modify surfaces created in previous turns. If the UI
 -----OUTPUT_FORMAT_START-----
 When constructing UI, you must output a VALID A2UI JSON object representing one of the A2UI message types (`createSurface`, `updateComponents`, `updateDataModel`).
 - You can treat the A2UI schema as a specification for the JSON you typically output.
-- You may include a brief conversational explanation before or after the JSON block if it helps the user, but the JSON block must be valid and complete.
+- The JSON block must be valid and complete.
 - Ensure your JSON is fenced with ```json and ```.
 -----OUTPUT_FORMAT_END-----
 

--- a/packages/genui/test/facade/prompt_builder_test.golden/update_only_with_dataModel_false.txt
+++ b/packages/genui/test/facade/prompt_builder_test.golden/update_only_with_dataModel_false.txt
@@ -109,7 +109,7 @@ To update an existing UI:
 -----OUTPUT_FORMAT_START-----
 When constructing UI, you must output a VALID A2UI JSON object representing one of the A2UI message types (`updateComponents`).
 - You can treat the A2UI schema as a specification for the JSON you typically output.
-- You may include a brief conversational explanation before or after the JSON block if it helps the user, but the JSON block must be valid and complete.
+- The JSON block must be valid and complete.
 - Ensure your JSON is fenced with ```json and ```.
 -----OUTPUT_FORMAT_END-----
 

--- a/packages/genui/test/facade/prompt_builder_test.golden/update_only_with_dataModel_true.txt
+++ b/packages/genui/test/facade/prompt_builder_test.golden/update_only_with_dataModel_true.txt
@@ -111,7 +111,7 @@ To update an existing UI:
 -----OUTPUT_FORMAT_START-----
 When constructing UI, you must output a VALID A2UI JSON object representing one of the A2UI message types (`updateComponents`, `updateDataModel`).
 - You can treat the A2UI schema as a specification for the JSON you typically output.
-- You may include a brief conversational explanation before or after the JSON block if it helps the user, but the JSON block must be valid and complete.
+- The JSON block must be valid and complete.
 - Ensure your JSON is fenced with ```json and ```.
 -----OUTPUT_FORMAT_END-----
 


### PR DESCRIPTION
# Description

The current output format instructions in prompt builder are "misleading" the LLM into returning free text in between A2UI messages. When removing this hint the LLM is a lot less likely to return these free text chunks.

There's no reference (that I can find!) in the A2UI spec that hints at servers or clients dealing with free text in the middle of A2UI messages. See for example the [v0.9 example stream](https://a2ui.org/specification/v0.9-a2ui/#example-stream), a "clean" list of JSON messages, no free text in between.

Personally I think that with this in mind `ConversationContentReceived` could / should be removed as a `ConversationEvent`, but that might be taking it a step too far for now. 

## Pre-launch Checklist

- [x] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [x] I signed the [CLA].
- [x] I read the [Contributors Guide].
- [ ] I have added sample code updates to the [changelog].
- [ ] I updated/added relevant documentation (doc comments with `///`).

If you need help, consider asking for advice on the #hackers-devrel channel on [Discord].

<!-- Links -->

[Flutter Style Guide]: https://github.com/flutter/flutter/blob/master/docs/contributing/Style-guide-for-Flutter-repo.md
[CLA]: https://cla.developers.google.com/
[Discord]: https://github.com/flutter/flutter/blob/master/docs/contributing/Chat.md
[Contributors Guide]: https://github.com/flutter/samples/blob/main/CONTRIBUTING.md
[changelog]: ../CHANGELOG.md
