### PR TITLE
Fix broken link to run_app_with_gemini_key.md in examples READMEs

### DIFF
--- a/packages/genui/CHANGELOG.md
+++ b/packages/genui/CHANGELOG.md
@@ -20,6 +20,7 @@
   an error.
 - The catalog-widget authoring API is unchanged; `SurfaceDefinition` and
   `Component` remain genui types.
+- **Fix**: Fixed broken link to `run_app_with_gemini_key.md` in `simple_chat` example README (#783).
 
 ## 0.9.1
 


### PR DESCRIPTION
# Description

Fixes #783                                                                                                                                 
The file was moved to `docs/usage/` but the links in two example READMEs still pointed to the old path, causing a 404.                                                                                                

Fixed in:                                                                                                                                    
- examples/travel_app/README.md                                                                                                            
- examples/simple_chat/README.md

## Pre-launch Checklist

- [x] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [x] I signed the [CLA].
- [x] I read the [Contributors Guide].
- [x] I have added sample code updates to the [changelog].
- [ ] I updated/added relevant documentation (doc comments with `///`).

If you need help, consider asking for advice on the #hackers-devrel channel on [Discord].

<!-- Links -->

[Flutter Style Guide]: https://github.com/flutter/flutter/blob/master/docs/contributing/Style-guide-for-Flutter-repo.md
[CLA]: https://cla.developers.google.com/
[Discord]: https://github.com/flutter/flutter/blob/master/docs/contributing/Chat.md
[Contributors Guide]: https://github.com/flutter/samples/blob/main/CONTRIBUTING.md
[changelog]: ../CHANGELOG.md
