### PR TITLE
fix(a2ui_core/data_model): notify descendant watches on root set

### DIFF
--- a/packages/a2ui_core/lib/src/core/data_model.dart
+++ b/packages/a2ui_core/lib/src/core/data_model.dart
@@ -149,6 +149,13 @@ class DataModel {
   void _notifyPathAndRelated(DataPath dataPath) {
     final normalizedPath = dataPath.toString();
 
+    if (dataPath.isEmpty) {
+      for (final String entryPath in _signals.keys.toList()) {
+        _getAndNotify(entryPath);
+      }
+      return;
+    }
+
     // Notify all active signals that are related to this path
     for (final String entryPath in _signals.keys.toList()) {
       if (entryPath == '/' || entryPath == '') {

--- a/packages/a2ui_core/lib/src/core/data_model.dart
+++ b/packages/a2ui_core/lib/src/core/data_model.dart
@@ -16,7 +16,7 @@ const int maxAutoVivifyIndex = 10000;
 /// It handles JSON Pointer path resolution and reactive signal management.
 class DataModel {
   Object? _data;
-  final Map<DataPath, WeakReference<Signal<Object?>>> _signals = {};
+  final Map<String, WeakReference<Signal<Object?>>> _signals = {};
 
   DataModel([Object? initialData]) : _data = initialData ?? <String, Object?>{};
 
@@ -28,7 +28,7 @@ class DataModel {
     Object? current = _data;
     for (final String segment in dataPath.segments) {
       if (current == null) return null;
-      if (current is Map<String, Object?>) {
+      if (current is Map<Object?, Object?>) {
         current = current[segment];
       } else if (current is List<Object?>) {
         final int? index = int.tryParse(segment);
@@ -56,7 +56,7 @@ class DataModel {
           final String nextSegment = dataPath.segments[i + 1];
           final isNextNumeric = int.tryParse(nextSegment) != null;
 
-          if (current is Map<String, Object?>) {
+          if (current is Map<Object?, Object?>) {
             if (!current.containsKey(segment) || current[segment] == null) {
               current[segment] = isNextNumeric
                   ? <Object?>[]
@@ -96,7 +96,7 @@ class DataModel {
         }
 
         final String lastSegment = dataPath.segments.last;
-        if (current is Map<String, Object?>) {
+        if (current is Map<Object?, Object?>) {
           if (value == null) {
             current.remove(lastSegment);
           } else {
@@ -130,8 +130,8 @@ class DataModel {
   /// Returns a [ReadonlySignal] for a specific path.
   /// Internally cached using a [WeakReference] to prevent leaks.
   ReadonlySignal<T?> watch<T>(String path) {
-    final key = DataPath.parse(path);
-    final WeakReference<Signal<Object?>>? ref = _signals[key];
+    final normalizedPath = DataPath.parse(path).toString();
+    final WeakReference<Signal<Object?>>? ref = _signals[normalizedPath];
     if (ref != null) {
       final Signal<Object?>? sig = ref.target;
       if (sig != null) {
@@ -139,30 +139,29 @@ class DataModel {
       }
     }
 
-    final Signal<T?> sig = signal<T?>(get(path) as T?);
-    _signals[key] = WeakReference(sig as Signal<Object?>);
+    final Signal<T?> sig = signal<T?>(get(normalizedPath) as T?);
+    _signals[normalizedPath] = WeakReference(sig as Signal<Object?>);
     _pruneSignals();
     return sig;
   }
 
   void _notifyPathAndRelated(DataPath dataPath) {
-    for (final DataPath entryPath in _signals.keys.toList()) {
-      if (_isPrefixOrEqual(dataPath.segments, entryPath.segments) ||
-          _isPrefixOrEqual(entryPath.segments, dataPath.segments)) {
+    final normalizedPath = dataPath.toString();
+    for (final String entryPath in _signals.keys.toList()) {
+      if (_isPathRelated(normalizedPath, entryPath)) {
         _getAndNotify(entryPath);
       }
     }
   }
 
-  bool _isPrefixOrEqual(List<String> prefix, List<String> path) {
-    if (prefix.length > path.length) return false;
-    for (var i = 0; i < prefix.length; i++) {
-      if (prefix[i] != path[i]) return false;
-    }
-    return true;
+  bool _isPathRelated(String a, String b) {
+    if (a == b) return true;
+    final descendantPrefixA = a == '/' ? '/' : '$a/';
+    final descendantPrefixB = b == '/' ? '/' : '$b/';
+    return b.startsWith(descendantPrefixA) || a.startsWith(descendantPrefixB);
   }
 
-  void _getAndNotify(DataPath path) {
+  void _getAndNotify(String path) {
     final WeakReference<Signal<Object?>>? ref = _signals[path];
     if (ref == null) return;
 
@@ -172,7 +171,7 @@ class DataModel {
       return;
     }
 
-    final Object? newValue = get(path.toString());
+    final Object? newValue = get(path);
     // Force notification even if the value is the same reference, because
     // mutable containers (Maps/Lists) may have changed in place.
     sig.set(newValue, force: true);

--- a/packages/a2ui_core/lib/src/core/data_model.dart
+++ b/packages/a2ui_core/lib/src/core/data_model.dart
@@ -16,10 +16,9 @@ const int maxAutoVivifyIndex = 10000;
 /// It handles JSON Pointer path resolution and reactive signal management.
 class DataModel {
   Object? _data;
-  final Map<String, WeakReference<Signal<Object?>>> _signals = {};
+  final Map<DataPath, WeakReference<Signal<Object?>>> _signals = {};
 
-  DataModel([Object? initialData])
-    : _data = initialData ?? <String, Object?>{};
+  DataModel([Object? initialData]) : _data = initialData ?? <String, Object?>{};
 
   /// Synchronously gets data at a specific JSON pointer path.
   Object? get(String path) {
@@ -131,9 +130,8 @@ class DataModel {
   /// Returns a [ReadonlySignal] for a specific path.
   /// Internally cached using a [WeakReference] to prevent leaks.
   ReadonlySignal<T?> watch<T>(String path) {
-    var normalizedPath = DataPath.parse(path).toString();
-    if (normalizedPath == '') normalizedPath = '/';
-    final WeakReference<Signal<Object?>>? ref = _signals[normalizedPath];
+    final key = DataPath.parse(path);
+    final WeakReference<Signal<Object?>>? ref = _signals[key];
     if (ref != null) {
       final Signal<Object?>? sig = ref.target;
       if (sig != null) {
@@ -141,17 +139,16 @@ class DataModel {
       }
     }
 
-    final Signal<T?> sig = signal<T?>(get(normalizedPath) as T?);
-    _signals[normalizedPath] = WeakReference(sig as Signal<Object?>);
+    final Signal<T?> sig = signal<T?>(get(path) as T?);
+    _signals[key] = WeakReference(sig as Signal<Object?>);
     _pruneSignals();
     return sig;
   }
 
   void _notifyPathAndRelated(DataPath dataPath) {
-    for (final String entryPath in _signals.keys.toList()) {
-      final List<String> entrySegments = DataPath.parse(entryPath).segments;
-      if (_isPrefixOrEqual(dataPath.segments, entrySegments) ||
-          _isPrefixOrEqual(entrySegments, dataPath.segments)) {
+    for (final DataPath entryPath in _signals.keys.toList()) {
+      if (_isPrefixOrEqual(dataPath.segments, entryPath.segments) ||
+          _isPrefixOrEqual(entryPath.segments, dataPath.segments)) {
         _getAndNotify(entryPath);
       }
     }
@@ -165,7 +162,7 @@ class DataModel {
     return true;
   }
 
-  void _getAndNotify(String path) {
+  void _getAndNotify(DataPath path) {
     final WeakReference<Signal<Object?>>? ref = _signals[path];
     if (ref == null) return;
 
@@ -175,7 +172,7 @@ class DataModel {
       return;
     }
 
-    final Object? newValue = get(path);
+    final Object? newValue = get(path.toString());
     // Force notification even if the value is the same reference, because
     // mutable containers (Maps/Lists) may have changed in place.
     sig.set(newValue, force: true);

--- a/packages/a2ui_core/lib/src/core/data_model.dart
+++ b/packages/a2ui_core/lib/src/core/data_model.dart
@@ -18,7 +18,8 @@ class DataModel {
   Object? _data;
   final Map<String, WeakReference<Signal<Object?>>> _signals = {};
 
-  DataModel([Object? initialData]) : _data = initialData ?? <String, dynamic>{};
+  DataModel([Object? initialData])
+    : _data = initialData ?? <String, Object?>{};
 
   /// Synchronously gets data at a specific JSON pointer path.
   Object? get(String path) {
@@ -28,9 +29,9 @@ class DataModel {
     Object? current = _data;
     for (final String segment in dataPath.segments) {
       if (current == null) return null;
-      if (current is Map) {
+      if (current is Map<String, Object?>) {
         current = current[segment];
-      } else if (current is List) {
+      } else if (current is List<Object?>) {
         final int? index = int.tryParse(segment);
         if (index == null || index < 0 || index >= current.length) return null;
         current = current[index];
@@ -49,21 +50,21 @@ class DataModel {
       if (dataPath.isEmpty) {
         _data = value;
       } else {
-        _data ??= <String, dynamic>{};
+        _data ??= <String, Object?>{};
         Object? current = _data;
         for (var i = 0; i < dataPath.segments.length - 1; i++) {
           final String segment = dataPath.segments[i];
           final String nextSegment = dataPath.segments[i + 1];
           final isNextNumeric = int.tryParse(nextSegment) != null;
 
-          if (current is Map) {
+          if (current is Map<String, Object?>) {
             if (!current.containsKey(segment) || current[segment] == null) {
               current[segment] = isNextNumeric
                   ? <Object?>[]
-                  : <String, dynamic>{};
+                  : <String, Object?>{};
             }
             current = current[segment];
-          } else if (current is List) {
+          } else if (current is List<Object?>) {
             final int? index = int.tryParse(segment);
             if (index == null) {
               throw A2uiDataError(
@@ -83,7 +84,7 @@ class DataModel {
             if (current[index] == null) {
               current[index] = isNextNumeric
                   ? <Object?>[]
-                  : <String, dynamic>{};
+                  : <String, Object?>{};
             }
             current = current[index];
           } else {
@@ -96,13 +97,13 @@ class DataModel {
         }
 
         final String lastSegment = dataPath.segments.last;
-        if (current is Map) {
+        if (current is Map<String, Object?>) {
           if (value == null) {
             current.remove(lastSegment);
           } else {
             current[lastSegment] = value;
           }
-        } else if (current is List) {
+        } else if (current is List<Object?>) {
           final int? index = int.tryParse(lastSegment);
           if (index == null) {
             throw A2uiDataError(

--- a/packages/a2ui_core/lib/src/core/data_model.dart
+++ b/packages/a2ui_core/lib/src/core/data_model.dart
@@ -25,20 +25,22 @@ class DataModel {
     final dataPath = DataPath.parse(path);
     if (dataPath.isEmpty) return _data;
 
-    Object? current = _data;
+    Object? currentNode = _data;
     for (final String segment in dataPath.segments) {
-      if (current == null) return null;
-      if (current is Map<Object?, Object?>) {
-        current = current[segment];
-      } else if (current is List<Object?>) {
+      if (currentNode == null) return null;
+      if (currentNode is Map<String, Object?>) {
+        currentNode = currentNode[segment];
+      } else if (currentNode is List<Object?>) {
         final int? index = int.tryParse(segment);
-        if (index == null || index < 0 || index >= current.length) return null;
-        current = current[index];
+        if (index == null || index < 0 || index >= currentNode.length) {
+          return null;
+        }
+        currentNode = currentNode[index];
       } else {
         return null;
       }
     }
-    return current;
+    return currentNode;
   }
 
   /// Updates data at a specific path and notifies subscribers.
@@ -56,7 +58,7 @@ class DataModel {
           final String nextSegment = dataPath.segments[i + 1];
           final isNextNumeric = int.tryParse(nextSegment) != null;
 
-          if (current is Map<Object?, Object?>) {
+          if (current is Map<String, Object?>) {
             if (!current.containsKey(segment) || current[segment] == null) {
               current[segment] = isNextNumeric
                   ? <Object?>[]
@@ -96,7 +98,7 @@ class DataModel {
         }
 
         final String lastSegment = dataPath.segments.last;
-        if (current is Map<Object?, Object?>) {
+        if (current is Map<String, Object?>) {
           if (value == null) {
             current.remove(lastSegment);
           } else {

--- a/packages/a2ui_core/lib/src/core/data_model.dart
+++ b/packages/a2ui_core/lib/src/core/data_model.dart
@@ -147,30 +147,23 @@ class DataModel {
   }
 
   void _notifyPathAndRelated(DataPath dataPath) {
-    final normalizedPath = dataPath.toString();
-
-    if (dataPath.isEmpty) {
-      for (final String entryPath in _signals.keys.toList()) {
-        _getAndNotify(entryPath);
-      }
-      return;
-    }
-
-    // Notify all active signals that are related to this path
     for (final String entryPath in _signals.keys.toList()) {
-      if (entryPath == '/' || entryPath == '') {
-        _getAndNotify(entryPath);
-        continue;
-      }
-
-      if (entryPath == normalizedPath) {
-        _getAndNotify(entryPath);
-      } else if (normalizedPath.startsWith('$entryPath/')) {
-        _getAndNotify(entryPath);
-      } else if (entryPath.startsWith('$normalizedPath/')) {
+      final List<String> entrySegments = DataPath.parse(entryPath).segments;
+      if (_isPrefixOrEqual(dataPath.segments, entrySegments) ||
+          _isPrefixOrEqual(entrySegments, dataPath.segments)) {
         _getAndNotify(entryPath);
       }
     }
+  }
+
+  /// An empty list is a prefix of every list — this is what makes root-vs-root
+  /// and root-vs-anything cases fall out without special-casing.
+  bool _isPrefixOrEqual(List<String> prefix, List<String> path) {
+    if (prefix.length > path.length) return false;
+    for (var i = 0; i < prefix.length; i++) {
+      if (prefix[i] != path[i]) return false;
+    }
+    return true;
   }
 
   void _getAndNotify(String path) {

--- a/packages/a2ui_core/lib/src/core/data_model.dart
+++ b/packages/a2ui_core/lib/src/core/data_model.dart
@@ -156,8 +156,6 @@ class DataModel {
     }
   }
 
-  /// An empty list is a prefix of every list — this is what makes root-vs-root
-  /// and root-vs-anything cases fall out without special-casing.
   bool _isPrefixOrEqual(List<String> prefix, List<String> path) {
     if (prefix.length > path.length) return false;
     for (var i = 0; i < prefix.length; i++) {

--- a/packages/a2ui_core/lib/src/core/data_model.dart
+++ b/packages/a2ui_core/lib/src/core/data_model.dart
@@ -146,20 +146,18 @@ class DataModel {
   }
 
   void _notifyPathAndRelated(DataPath dataPath) {
-    final normalizedPath = dataPath.toString();
+    final changedPath = dataPath.toString();
+    final String changedDescendantPrefix = _descendantPrefix(changedPath);
     for (final String entryPath in _signals.keys.toList()) {
-      if (_isPathRelated(normalizedPath, entryPath)) {
+      if (changedPath == entryPath ||
+          entryPath.startsWith(changedDescendantPrefix) ||
+          changedPath.startsWith(_descendantPrefix(entryPath))) {
         _getAndNotify(entryPath);
       }
     }
   }
 
-  bool _isPathRelated(String a, String b) {
-    if (a == b) return true;
-    final descendantPrefixA = a == '/' ? '/' : '$a/';
-    final descendantPrefixB = b == '/' ? '/' : '$b/';
-    return b.startsWith(descendantPrefixA) || a.startsWith(descendantPrefixB);
-  }
+  static String _descendantPrefix(String path) => path == '/' ? '/' : '$path/';
 
   void _getAndNotify(String path) {
     final WeakReference<Signal<Object?>>? ref = _signals[path];

--- a/packages/a2ui_core/test/data_model_test.dart
+++ b/packages/a2ui_core/test/data_model_test.dart
@@ -81,6 +81,30 @@ void main() {
       expect(changeCount, 1);
     });
 
+    test('notifies descendant watches on root changes', () {
+      final model = DataModel({
+        'user': {'name': 'Alice'},
+        'stale': 'present',
+      });
+      final ReadonlySignal<Object?> nameWatch = model.watch('/user/name');
+      final ReadonlySignal<Object?> staleWatch = model.watch('/stale');
+      var nameChangeCount = 0;
+      var staleChangeCount = 0;
+      nameWatch.subscribe((_) => nameChangeCount++);
+      staleWatch.subscribe((_) => staleChangeCount++);
+      nameChangeCount = 0;
+      staleChangeCount = 0;
+
+      model.set('/', {
+        'user': {'name': 'Bob'},
+      });
+
+      expect(nameChangeCount, 1);
+      expect(nameWatch.value, 'Bob');
+      expect(staleChangeCount, 1);
+      expect(staleWatch.value, isNull);
+    });
+
     test('removes keys when setting null', () {
       final model = DataModel({'foo': 'bar'});
       model.set('/foo', null);

--- a/packages/a2ui_core/test/data_model_test.dart
+++ b/packages/a2ui_core/test/data_model_test.dart
@@ -105,6 +105,40 @@ void main() {
       expect(staleWatch.value, isNull);
     });
 
+    test('notifies root watch on root set', () {
+      final model = DataModel({'foo': 'bar'});
+      final ReadonlySignal<Object?> rootWatch = model.watch('/');
+      var changeCount = 0;
+      rootWatch.subscribe((_) => changeCount++);
+      changeCount = 0;
+
+      model.set('/', {'baz': 'qux'});
+      expect(changeCount, 1);
+      expect(rootWatch.value, {'baz': 'qux'});
+    });
+
+    test('does not notify unrelated paths', () {
+      final model = DataModel({'a': 1, 'b': 2});
+      final ReadonlySignal<Object?> bWatch = model.watch('/b');
+      var bChangeCount = 0;
+      bWatch.subscribe((_) => bChangeCount++);
+      bChangeCount = 0;
+
+      model.set('/a', 99);
+      expect(bChangeCount, 0);
+    });
+
+    test('does not notify a sibling whose name shares a prefix', () {
+      final model = DataModel({'foo': 1, 'foobar': 2});
+      final ReadonlySignal<Object?> foobarWatch = model.watch('/foobar');
+      var foobarChangeCount = 0;
+      foobarWatch.subscribe((_) => foobarChangeCount++);
+      foobarChangeCount = 0;
+
+      model.set('/foo', 99);
+      expect(foobarChangeCount, 0);
+    });
+
     test('removes keys when setting null', () {
       final model = DataModel({'foo': 'bar'});
       model.set('/foo', null);


### PR DESCRIPTION
Part of work on https://github.com/flutter/genui/issues/811

## Bug
In a2ui_core's `DataModel._notifyPathAndRelated`, `set('/', value)` would not notify subscribers at descendant paths (`/foo`, `/foo/bar`, etc.). Root path was treated as `'/'` in a `startsWith('$normalizedPath/')` check, which became `startsWith('//')` and never matched. Discovered while working on a2ui_core migration work.

## Fix
Replaces the ad-hoc string-prefix arithmetic with a small `_descendantPrefix` helper that isolates the root special case. The body of `_notifyPathAndRelated` can then check that one of three simple conditions is satisfied: equal, entry is descendant of changed, or changed is descendant of entry. Adds some test cases, which were verified as failing prior to the fix.

Unrelated cleanup: also tightens `Map`/`List` type checks in path traversal to `Map<Object?, Object?>` / `List<Object?>` so internal code propagates `Object?` instead of `dynamic`.

## Pre-launch Checklist
- [x] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [x] I signed the [CLA].
- [x] I read the [Contributors Guide].
- [x] I have added sample code updates to the [changelog].
- [x] I updated/added relevant documentation (doc comments with `///`).

<!-- Links -->

[Flutter Style Guide]: https://github.com/flutter/flutter/blob/master/docs/contributing/Style-guide-for-Flutter-repo.md
[CLA]: https://cla.developers.google.com/
[Discord]: https://github.com/flutter/flutter/blob/master/docs/contributing/Chat.md
[Contributors Guide]: https://github.com/flutter/samples/blob/main/CONTRIBUTING.md
[changelog]: ../CHANGELOG.md
