### PR TITLE
Replace outdated information in README with link to full example registry.

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -1,32 +1,6 @@
 # Examples
 
-This directory contains example applications demonstrating the `genui` SDK
-capabilities.
-
-## Overview
-
-| Example                            | Complexity   | Backend            | Description                                        |
-| ---------------------------------- | ------------ | ------------------ | -------------------------------------------------- |
-| [catalog_gallery][catalog_gallery] | Simple       | None               | Visual reference for basic catalog widgets         |
-| [simple_chat][simple_chat]         | Intermediate | Firebase/Google AI | A simple, conversational chat application.         |
-| [travel_app][travel_app]           | Advanced     | Firebase/Google AI | Full travel planning assistant with custom catalog |
-| [verdure][verdure]                 | Advanced     | Python A2A Server  | Full-stack landscape design agent                  |
-
-[catalog_gallery]: https://github.com/flutter/genui/tree/main/examples/catalog_gallery
-[simple_chat]: https://github.com/flutter/genui/tree/main/examples/simple_chat
-[travel_app]: https://github.com/flutter/genui/tree/main/examples/travel_app
-[verdure]: https://github.com/flutter/genui/tree/main/examples/verdure
-
-Each example directory contains a more detailed `README.md` file with
-its specific instructions.
-
----
-
-## Choosing an Example
-
-| Goal                                            | Recommended Example |
-| ----------------------------------------------- | ------------------- |
-| Understand basic a2ui components                | `catalog_gallery`   |
-| Basic use of the SDK                            | `simple_chat`       |
-| Build a production-like app with custom catalog | `travel_app`        |
-| Implement client-server architecture with A2A   | `verdure`           |
+This directory contains example applications demonstrating the A2UI Dart SDK capabilities.
+ 
+See [A2UI example registry](https://github.com/google/A2UI/blob/main/samples/README.md)
+for more details on these and other examples.

--- a/packages/genui/CHANGELOG.md
+++ b/packages/genui/CHANGELOG.md
@@ -1,5 +1,9 @@
 # `genui` Changelog
 
+## (WIP)
+
+- **Feature**: Updated example/README.md.
+
 ## 0.9.0
 
 - **BREAKING**: Reorganized library exports (#866).

--- a/packages/genui/example/README.md
+++ b/packages/genui/example/README.md
@@ -1,9 +1,1 @@
-Check the `examples` directory at the root of the `flutter/genui` monorepo for
-several sample apps demonstrating the SDK:
-
-* https://github.com/flutter/genui/tree/main/examples
-
-Each example is backed by a different backend stack. Check the [README.md][1]
-file there for more information about each example.
-
-[1]: https://github.com/flutter/genui/blob/main/examples/README.md
+See [A2UI example registry](https://github.com/google/A2UI/blob/main/samples/README.md) for examples of using the A2UI Dart SDK, and SDKs for other languages.


### PR DESCRIPTION
Contributes to https://github.com/flutter/genui/issues/907

Replace outdated information in README with link to full example registry.
Fixe capitalization of A2UI in documentation.