### PR TITLE
fix(a2ui_core): make `A2uiMessage.fromJson` reject messages with more than one type

### DIFF
--- a/packages/a2ui_core/lib/src/core/messages.dart
+++ b/packages/a2ui_core/lib/src/core/messages.dart
@@ -13,6 +13,23 @@ abstract class A2uiMessage {
   factory A2uiMessage.fromJson(Map<String, dynamic> json) {
     final String version = json['version'] as String? ?? 'v0.9';
 
+    const messageBodyKeys = {
+      'createSurface',
+      'updateComponents',
+      'updateDataModel',
+      'deleteSurface',
+    };
+    final List<String> presentKeys = messageBodyKeys
+        .where(json.containsKey)
+        .toList();
+    if (presentKeys.length > 1) {
+      throw A2uiValidationError(
+        'A2UI message must contain exactly one of '
+        '${messageBodyKeys.join(', ')}; got ${presentKeys.join(', ')}.',
+        details: json,
+      );
+    }
+
     if (json.containsKey('createSurface')) {
       final body = json['createSurface'] as Map<String, dynamic>;
       return CreateSurfaceMessage(
@@ -53,7 +70,7 @@ abstract class A2uiMessage {
 
     throw A2uiValidationError(
       'Unknown A2UI message type. Expected one of: '
-      'createSurface, updateComponents, updateDataModel, deleteSurface.',
+      '${messageBodyKeys.join(', ')}.',
       details: json,
     );
   }

--- a/packages/a2ui_core/test/messages_test.dart
+++ b/packages/a2ui_core/test/messages_test.dart
@@ -105,6 +105,20 @@ void main() {
       );
     });
 
+    test('throws when envelope contains more than one message-body key', () {
+      // The v0.9 schema is oneOf the four message-body keys; an envelope
+      // that carries more than one is invalid and must not be silently
+      // coerced to whichever branch happens to be checked first.
+      expect(
+        () => A2uiMessage.fromJson({
+          'version': 'v0.9',
+          'createSurface': {'surfaceId': 's1', 'catalogId': 'c1'},
+          'updateComponents': {'surfaceId': 's1', 'components': <Object?>[]},
+        }),
+        throwsA(isA<A2uiValidationError>()),
+      );
+    });
+
     test('roundtrips through toJson/fromJson', () {
       final original = CreateSurfaceMessage(
         surfaceId: 's1',


### PR DESCRIPTION
See #934. This bug also exists in the `a2ui_core`. This PR is the `a2ui_core` fix. I don't plan on fixing it in `genui` separately because we will move `genui` onto a`2ui_core` very soon.

web_core enforces the constraint in `MessageProcessor.processMessage`[^1] and via `.strict()` on its Zod schemas[^2]. This commit takes the former approach.

[^1]: https://github.com/google/A2UI/blob/0e0375749bf8a940d57969d612e74f7221ad246e/renderers/web_core/src/v0_9/processing/message-processor.ts#L229-L262
[^2]: https://github.com/google/A2UI/blob/0e0375749bf8a940d57969d612e74f7221ad246e/renderers/web_core/src/v0_9/schema/server-to-client.ts