### PR TITLE
fix(genui): A2uiMessage.fromJson rejects messages with more than one type

### DIFF
--- a/packages/genui/lib/src/model/a2ui_message.dart
+++ b/packages/genui/lib/src/model/a2ui_message.dart
@@ -26,6 +26,22 @@ sealed class A2uiMessage {
           json: json,
         );
       }
+      const messageBodyKeys = {
+        'createSurface',
+        'updateComponents',
+        'updateDataModel',
+        'deleteSurface',
+      };
+      final List<String> presentKeys = messageBodyKeys
+          .where(json.containsKey)
+          .toList();
+      if (presentKeys.length > 1) {
+        throw A2uiValidationException(
+          'A2UI message must contain exactly one of '
+          '${messageBodyKeys.join(', ')}; got ${presentKeys.join(', ')}.',
+          json: json,
+        );
+      }
       if (json case {'createSurface': JsonMap data}) {
         try {
           return CreateSurface.fromJson(data);

--- a/packages/genui/test/model/a2ui_message_test.dart
+++ b/packages/genui/test/model/a2ui_message_test.dart
@@ -119,6 +119,18 @@ void main() {
       );
     });
 
+    test('fromJson throws when more than one message type is set', () {
+      final json = <String, Object>{
+        'version': 'v0.9',
+        'createSurface': {surfaceIdKey: 's1', 'catalogId': 'c1'},
+        'updateComponents': {surfaceIdKey: 's1', 'components': <Object?>[]},
+      };
+      expect(
+        () => A2uiMessage.fromJson(json),
+        throwsA(isA<A2uiValidationException>()),
+      );
+    });
+
     test('fromJson throws on missing or invalid version', () {
       final json = <String, Object>{
         'createSurface': {surfaceIdKey: 's1', 'catalogId': 'c1'},


### PR DESCRIPTION
Fixes #934.

Related: https://github.com/flutter/genui/pull/936. fixes the same bug in a2ui_core