### PR TITLE
fix(a2ui_core): distinguish between `"key": null` and absence of `key` in DataModel

### DIFF
--- a/packages/a2ui_core/lib/src/core/data_model.dart
+++ b/packages/a2ui_core/lib/src/core/data_model.dart
@@ -94,13 +94,13 @@ class DataModel {
     Object? current = _data;
     for (var i = 0; i < dataPath.segments.length - 1; i++) {
       final String segment = dataPath.segments[i];
-      final String nextSegment = dataPath.segments[i + 1];
-      final isNextNumeric = int.tryParse(nextSegment) != null;
 
       if (current is Map<String, Object?>) {
         if (!current.containsKey(segment) || current[segment] == null) {
           if (!autoVivify) return null;
-          current[segment] = isNextNumeric ? <Object?>[] : <String, Object?>{};
+          current[segment] = int.tryParse(dataPath.segments[i + 1]) != null
+              ? <Object?>[]
+              : <String, Object?>{};
         }
         current = current[segment];
       } else if (current is List<Object?>) {
@@ -124,7 +124,9 @@ class DataModel {
           while (current.length <= index) {
             current.add(null);
           }
-          current[index] = isNextNumeric ? <Object?>[] : <String, Object?>{};
+          current[index] = int.tryParse(dataPath.segments[i + 1]) != null
+              ? <Object?>[]
+              : <String, Object?>{};
         }
         current = current[index];
       } else {

--- a/packages/a2ui_core/lib/src/core/data_model.dart
+++ b/packages/a2ui_core/lib/src/core/data_model.dart
@@ -106,12 +106,14 @@ class DataModel {
       } else if (current is List<Object?>) {
         final int? index = int.tryParse(segment);
         if (index == null) {
+          if (!autoVivify) return null;
           throw A2uiDataError(
             "Cannot use non-numeric segment '$segment' on a list.",
             path: path,
           );
         }
         if (index < 0 || index > maxAutoVivifyIndex) {
+          if (!autoVivify) return null;
           throw A2uiDataError(
             'List index out of bounds: $index (max $maxAutoVivifyIndex)',
             path: path,
@@ -163,6 +165,11 @@ class DataModel {
         parent.add(null);
       }
       parent[index] = value;
+    } else {
+      throw A2uiDataError(
+        "Cannot set path '$path': parent is a primitive.",
+        path: path,
+      );
     }
   }
 

--- a/packages/a2ui_core/lib/src/core/data_model.dart
+++ b/packages/a2ui_core/lib/src/core/data_model.dart
@@ -43,7 +43,8 @@ class DataModel {
     return currentNode;
   }
 
-  /// Updates data at a specific path and notifies subscribers.
+  /// Writes [value] at [path]. `value: null` sets the key to `null`; use
+  /// [remove] to delete a key.
   void set(String path, Object? value) {
     final dataPath = DataPath.parse(path);
 
@@ -51,82 +52,118 @@ class DataModel {
       if (dataPath.isEmpty) {
         _data = value;
       } else {
-        _data ??= <String, Object?>{};
-        Object? current = _data;
-        for (var i = 0; i < dataPath.segments.length - 1; i++) {
-          final String segment = dataPath.segments[i];
-          final String nextSegment = dataPath.segments[i + 1];
-          final isNextNumeric = int.tryParse(nextSegment) != null;
+        final Object? parent = _walkToParent(dataPath, path, autoVivify: true);
+        _writeLeaf(parent, dataPath.segments.last, value, path);
+      }
+      _notifyPathAndRelated(dataPath);
+    });
+  }
 
-          if (current is Map<String, Object?>) {
-            if (!current.containsKey(segment) || current[segment] == null) {
-              current[segment] = isNextNumeric
-                  ? <Object?>[]
-                  : <String, Object?>{};
-            }
-            current = current[segment];
-          } else if (current is List<Object?>) {
-            final int? index = int.tryParse(segment);
-            if (index == null) {
-              throw A2uiDataError(
-                "Cannot use non-numeric segment '$segment' on a list.",
-                path: path,
-              );
-            }
-            if (index < 0 || index > maxAutoVivifyIndex) {
-              throw A2uiDataError(
-                'List index out of bounds: $index (max $maxAutoVivifyIndex)',
-                path: path,
-              );
-            }
-            while (current.length <= index) {
-              current.add(null);
-            }
-            if (current[index] == null) {
-              current[index] = isNextNumeric
-                  ? <Object?>[]
-                  : <String, Object?>{};
-            }
-            current = current[index];
-          } else {
-            throw A2uiDataError(
-              "Cannot set path '$path': intermediate segment '$segment' is a "
-              'primitive.',
-              path: path,
-            );
-          }
-        }
+  /// Removes the value at [path]. For map keys this deletes the key; for
+  /// list indices it sets the slot to null and preserves length.
+  /// No-op if any intermediate segment is missing or wrong-typed.
+  /// `remove('/')` resets the data model to an empty map.
+  void remove(String path) {
+    final dataPath = DataPath.parse(path);
 
+    batch(() {
+      if (dataPath.isEmpty) {
+        _data = <String, Object?>{};
+      } else {
+        final Object? parent = _walkToParent(dataPath, path, autoVivify: false);
+        if (parent == null) return;
         final String lastSegment = dataPath.segments.last;
-        if (current is Map<String, Object?>) {
-          if (value == null) {
-            current.remove(lastSegment);
-          } else {
-            current[lastSegment] = value;
-          }
-        } else if (current is List<Object?>) {
+        if (parent is Map<String, Object?>) {
+          parent.remove(lastSegment);
+        } else if (parent is List<Object?>) {
           final int? index = int.tryParse(lastSegment);
-          if (index == null) {
-            throw A2uiDataError(
-              "Cannot use non-numeric segment '$lastSegment' on a list.",
-              path: path,
-            );
-          }
-          if (index < 0 || index > maxAutoVivifyIndex) {
-            throw A2uiDataError(
-              'List index out of bounds: $index (max $maxAutoVivifyIndex)',
-              path: path,
-            );
-          }
+          if (index == null || index < 0 || index >= parent.length) return;
+          parent[index] = null;
+        }
+      }
+      _notifyPathAndRelated(dataPath);
+    });
+  }
+
+  Object? _walkToParent(
+    DataPath dataPath,
+    String path, {
+    required bool autoVivify,
+  }) {
+    if (autoVivify) _data ??= <String, Object?>{};
+    Object? current = _data;
+    for (var i = 0; i < dataPath.segments.length - 1; i++) {
+      final String segment = dataPath.segments[i];
+      final String nextSegment = dataPath.segments[i + 1];
+      final isNextNumeric = int.tryParse(nextSegment) != null;
+
+      if (current is Map<String, Object?>) {
+        if (!current.containsKey(segment) || current[segment] == null) {
+          if (!autoVivify) return null;
+          current[segment] = isNextNumeric ? <Object?>[] : <String, Object?>{};
+        }
+        current = current[segment];
+      } else if (current is List<Object?>) {
+        final int? index = int.tryParse(segment);
+        if (index == null) {
+          throw A2uiDataError(
+            "Cannot use non-numeric segment '$segment' on a list.",
+            path: path,
+          );
+        }
+        if (index < 0 || index > maxAutoVivifyIndex) {
+          throw A2uiDataError(
+            'List index out of bounds: $index (max $maxAutoVivifyIndex)',
+            path: path,
+          );
+        }
+        if (index >= current.length || current[index] == null) {
+          if (!autoVivify) return null;
           while (current.length <= index) {
             current.add(null);
           }
-          current[index] = value;
+          current[index] = isNextNumeric ? <Object?>[] : <String, Object?>{};
         }
+        current = current[index];
+      } else {
+        if (!autoVivify) return null;
+        throw A2uiDataError(
+          "Cannot set path '$path': intermediate segment '$segment' is a "
+          'primitive.',
+          path: path,
+        );
       }
+    }
+    return current;
+  }
 
-      _notifyPathAndRelated(dataPath);
-    });
+  void _writeLeaf(
+    Object? parent,
+    String lastSegment,
+    Object? value,
+    String path,
+  ) {
+    if (parent is Map<String, Object?>) {
+      parent[lastSegment] = value;
+    } else if (parent is List<Object?>) {
+      final int? index = int.tryParse(lastSegment);
+      if (index == null) {
+        throw A2uiDataError(
+          "Cannot use non-numeric segment '$lastSegment' on a list.",
+          path: path,
+        );
+      }
+      if (index < 0 || index > maxAutoVivifyIndex) {
+        throw A2uiDataError(
+          'List index out of bounds: $index (max $maxAutoVivifyIndex)',
+          path: path,
+        );
+      }
+      while (parent.length <= index) {
+        parent.add(null);
+      }
+      parent[index] = value;
+    }
   }
 
   /// Returns a [ReadonlySignal] for a specific path.

--- a/packages/a2ui_core/lib/src/core/messages.dart
+++ b/packages/a2ui_core/lib/src/core/messages.dart
@@ -9,7 +9,7 @@ abstract class A2uiMessage {
   final String version;
   A2uiMessage({this.version = 'v0.9'});
 
-  /// Deserializes a JSON envelope into a typed [A2uiMessage].
+  /// Parses an A2UI JSON message into a typed [A2uiMessage].
   factory A2uiMessage.fromJson(Map<String, dynamic> json) {
     final String version = json['version'] as String? ?? 'v0.9';
 
@@ -35,11 +35,18 @@ abstract class A2uiMessage {
 
     if (json.containsKey('updateDataModel')) {
       final body = json['updateDataModel'] as Map<String, dynamic>;
-      return UpdateDataModelMessage(
+      if (body.containsKey('value')) {
+        return UpdateDataModelMessage(
+          version: version,
+          surfaceId: body['surfaceId'] as String,
+          path: body['path'] as String?,
+          value: body['value'],
+        );
+      }
+      return UpdateDataModelMessage.removeKey(
         version: version,
         surfaceId: body['surfaceId'] as String,
         path: body['path'] as String?,
-        value: body['value'],
       );
     }
 
@@ -111,13 +118,21 @@ class UpdateDataModelMessage extends A2uiMessage {
   final String surfaceId;
   final String? path;
   final Object? value;
+  final bool hasValue;
 
   UpdateDataModelMessage({
     super.version,
     required this.surfaceId,
     this.path,
     this.value,
-  });
+  }) : hasValue = true;
+
+  UpdateDataModelMessage.removeKey({
+    super.version,
+    required this.surfaceId,
+    this.path,
+  }) : value = null,
+       hasValue = false;
 
   @override
   Map<String, dynamic> toJson() => {
@@ -125,7 +140,7 @@ class UpdateDataModelMessage extends A2uiMessage {
     'updateDataModel': {
       'surfaceId': surfaceId,
       if (path != null) 'path': path,
-      if (value != null) 'value': value,
+      if (hasValue) 'value': value,
     },
   };
 }

--- a/packages/a2ui_core/lib/src/processing/processor.dart
+++ b/packages/a2ui_core/lib/src/processing/processor.dart
@@ -108,7 +108,12 @@ class MessageProcessor<T extends ComponentApi> {
       throw A2uiStateError('Surface not found: ${message.surfaceId}');
     }
 
-    surface.dataModel.set(message.path ?? '/', message.value);
+    final String path = message.path ?? '/';
+    if (message.hasValue) {
+      surface.dataModel.set(path, message.value);
+    } else {
+      surface.dataModel.remove(path);
+    }
   }
 
   void _processDeleteSurface(DeleteSurfaceMessage message) {
@@ -136,7 +141,6 @@ class MessageProcessor<T extends ComponentApi> {
       final Map<String, dynamic> jsonSchema = entry.value.schema.toJsonMap();
       _processRefs(jsonSchema);
 
-      // Wrap in A2UI envelope
       components[entry.key] = {
         'allOf': [
           {'\$ref': 'common_types.json#/\$defs/ComponentCommon'},

--- a/packages/a2ui_core/test/data_model_test.dart
+++ b/packages/a2ui_core/test/data_model_test.dart
@@ -139,9 +139,36 @@ void main() {
       expect(foobarChangeCount, 0);
     });
 
-    test('removes keys when setting null', () {
-      final model = DataModel({'foo': 'bar'});
+    test('set(path, null) sets the key to literal null', () {
+      final model = DataModel(<String, Object?>{'foo': 'bar', 'baz': 1});
       model.set('/foo', null);
+      expect(model.get('/'), {'foo': null, 'baz': 1});
+    });
+
+    test('remove(path) deletes the key from a map', () {
+      final model = DataModel(<String, Object?>{'foo': 'bar', 'baz': 1});
+      model.remove('/foo');
+      expect(model.get('/'), {'baz': 1});
+    });
+
+    test('remove(path) sets a list index to null and preserves length', () {
+      final model = DataModel(<String, Object?>{
+        'items': <Object?>['a', 'b', 'c'],
+      });
+      model.remove('/items/1');
+      expect(model.get('/items'), ['a', null, 'c']);
+    });
+
+    test('remove(path) is a no-op for non-existent paths', () {
+      final model = DataModel(<String, Object?>{'foo': 'bar'});
+      model.remove('/nonexistent');
+      model.remove('/foo/nested/deep');
+      expect(model.get('/'), {'foo': 'bar'});
+    });
+
+    test('remove(/) resets the data model to an empty map', () {
+      final model = DataModel(<String, Object?>{'foo': 'bar', 'baz': 1});
+      model.remove('/');
       expect(model.get('/'), isEmpty);
     });
 

--- a/packages/a2ui_core/test/data_model_test.dart
+++ b/packages/a2ui_core/test/data_model_test.dart
@@ -183,5 +183,32 @@ void main() {
         throwsA(isA<A2uiDataError>()),
       );
     });
+
+    test(
+      'remove(path) no-ops on out-of-bounds or non-numeric list indices',
+      () {
+        final model = DataModel(<String, Object?>{
+          'items': <Object?>['a', 'b'],
+        });
+        model.remove('/items/999999999');
+        model.remove('/items/foo/bar');
+        expect(model.get('/items'), ['a', 'b']);
+      },
+    );
+
+    test('set(path, value) throws when the parent is a primitive', () {
+      final model = DataModel();
+      model.set('/x', 5);
+      expect(() => model.set('/x/y', 'oops'), throwsA(isA<A2uiDataError>()));
+    });
+
+    test(
+      'set throws when the root is a primitive and the path is non-empty',
+      () {
+        final model = DataModel();
+        model.set('/', 5);
+        expect(() => model.set('/x', 'oops'), throwsA(isA<A2uiDataError>()));
+      },
+    );
   });
 }

--- a/packages/a2ui_core/test/messages_test.dart
+++ b/packages/a2ui_core/test/messages_test.dart
@@ -85,22 +85,6 @@ void main() {
       expect(ud.hasValue, isFalse);
     });
 
-    test('parses updateDataModel with explicit null value', () {
-      final message =
-          A2uiMessage.fromJson({
-                'version': 'v0.9',
-                'updateDataModel': {
-                  'surfaceId': 's1',
-                  'path': '/x',
-                  'value': null,
-                },
-              })
-              as UpdateDataModelMessage;
-
-      expect(message.value, isNull);
-      expect(message.hasValue, isTrue);
-    });
-
     test('round-trips an explicit-null updateDataModel value', () {
       final original = A2uiMessage.fromJson({
         'version': 'v0.9',

--- a/packages/a2ui_core/test/messages_test.dart
+++ b/packages/a2ui_core/test/messages_test.dart
@@ -82,6 +82,46 @@ void main() {
       final ud = msg as UpdateDataModelMessage;
       expect(ud.path, isNull);
       expect(ud.value, isNull);
+      expect(ud.hasValue, isFalse);
+    });
+
+    test('parses updateDataModel with explicit null value', () {
+      final msg = A2uiMessage.fromJson({
+        'version': 'v0.9',
+        'updateDataModel': {'surfaceId': 's1', 'path': '/x', 'value': null},
+      });
+
+      final ud = msg as UpdateDataModelMessage;
+      expect(ud.value, isNull);
+      expect(ud.hasValue, isTrue);
+    });
+
+    test('round-trips an explicit-null updateDataModel value', () {
+      final original = A2uiMessage.fromJson({
+        'version': 'v0.9',
+        'updateDataModel': {'surfaceId': 's1', 'path': '/x', 'value': null},
+      });
+      final Map<String, dynamic> json = original.toJson();
+      final body = json['updateDataModel'] as Map<String, dynamic>;
+      expect(body.containsKey('value'), isTrue);
+      expect(body['value'], isNull);
+
+      final reparsed = A2uiMessage.fromJson(json) as UpdateDataModelMessage;
+      expect(reparsed.hasValue, isTrue);
+      expect(reparsed.value, isNull);
+    });
+
+    test('round-trips an omitted updateDataModel value as omitted', () {
+      final omitted = UpdateDataModelMessage.removeKey(
+        surfaceId: 's1',
+        path: '/x',
+      );
+      final body = omitted.toJson()['updateDataModel'] as Map<String, dynamic>;
+      expect(body.containsKey('value'), isFalse);
+
+      final reparsed =
+          A2uiMessage.fromJson(omitted.toJson()) as UpdateDataModelMessage;
+      expect(reparsed.hasValue, isFalse);
     });
 
     test('parses deleteSurface', () {

--- a/packages/a2ui_core/test/messages_test.dart
+++ b/packages/a2ui_core/test/messages_test.dart
@@ -86,14 +86,19 @@ void main() {
     });
 
     test('parses updateDataModel with explicit null value', () {
-      final msg = A2uiMessage.fromJson({
-        'version': 'v0.9',
-        'updateDataModel': {'surfaceId': 's1', 'path': '/x', 'value': null},
-      });
+      final message =
+          A2uiMessage.fromJson({
+                'version': 'v0.9',
+                'updateDataModel': {
+                  'surfaceId': 's1',
+                  'path': '/x',
+                  'value': null,
+                },
+              })
+              as UpdateDataModelMessage;
 
-      final ud = msg as UpdateDataModelMessage;
-      expect(ud.value, isNull);
-      expect(ud.hasValue, isTrue);
+      expect(message.value, isNull);
+      expect(message.hasValue, isTrue);
     });
 
     test('round-trips an explicit-null updateDataModel value', () {
@@ -101,12 +106,14 @@ void main() {
         'version': 'v0.9',
         'updateDataModel': {'surfaceId': 's1', 'path': '/x', 'value': null},
       });
-      final Map<String, dynamic> json = original.toJson();
-      final body = json['updateDataModel'] as Map<String, dynamic>;
-      expect(body.containsKey('value'), isTrue);
-      expect(body['value'], isNull);
+      final Map<String, Object?> serialized = original.toJson();
+      final updateDataModelBody =
+          serialized['updateDataModel'] as Map<String, Object?>;
+      expect(updateDataModelBody.containsKey('value'), isTrue);
+      expect(updateDataModelBody['value'], isNull);
 
-      final reparsed = A2uiMessage.fromJson(json) as UpdateDataModelMessage;
+      final reparsed =
+          A2uiMessage.fromJson(serialized) as UpdateDataModelMessage;
       expect(reparsed.hasValue, isTrue);
       expect(reparsed.value, isNull);
     });
@@ -116,8 +123,9 @@ void main() {
         surfaceId: 's1',
         path: '/x',
       );
-      final body = omitted.toJson()['updateDataModel'] as Map<String, dynamic>;
-      expect(body.containsKey('value'), isFalse);
+      final updateDataModelBody =
+          omitted.toJson()['updateDataModel'] as Map<String, Object?>;
+      expect(updateDataModelBody.containsKey('value'), isFalse);
 
       final reparsed =
           A2uiMessage.fromJson(omitted.toJson()) as UpdateDataModelMessage;

--- a/packages/a2ui_core/test/processor_test.dart
+++ b/packages/a2ui_core/test/processor_test.dart
@@ -67,6 +67,42 @@ void main() {
       expect(surface?.dataModel.get('/user/name'), 'Alice');
     });
 
+    test('updateDataModel with explicit value: null sets key to null', () {
+      processor.processMessages([
+        CreateSurfaceMessage(surfaceId: 's1', catalogId: catalog.id),
+        UpdateDataModelMessage(
+          surfaceId: 's1',
+          path: '/user/name',
+          value: 'Alice',
+        ),
+        UpdateDataModelMessage(
+          surfaceId: 's1',
+          path: '/user/name',
+          value: null,
+        ),
+      ]);
+
+      final SurfaceModel<ComponentApi>? surface = processor.groupModel
+          .getSurface('s1');
+      expect(surface?.dataModel.get('/user'), {'name': null});
+    });
+
+    test('updateDataModel with omitted value (removeKey) deletes the key', () {
+      processor.processMessages([
+        CreateSurfaceMessage(surfaceId: 's1', catalogId: catalog.id),
+        UpdateDataModelMessage(
+          surfaceId: 's1',
+          path: '/user/name',
+          value: 'Alice',
+        ),
+        UpdateDataModelMessage.removeKey(surfaceId: 's1', path: '/user/name'),
+      ]);
+
+      final SurfaceModel<ComponentApi>? surface = processor.groupModel
+          .getSurface('s1');
+      expect(surface?.dataModel.get('/user'), isEmpty);
+    });
+
     test('deletes surface', () {
       processor.processMessages([
         CreateSurfaceMessage(surfaceId: 's1', catalogId: catalog.id),


### PR DESCRIPTION
See https://github.com/flutter/genui/issues/935.


This bug is also present in `genui`. However, to reduce churn, I recommend just waiting until we rebuild `genui` on top of `a2ui_core`.