### PR TITLE
fix(a2ui_core): make `A2uiMessage.fromJson` reject invalid version values

### DIFF
--- a/packages/a2ui_core/lib/src/core/messages.dart
+++ b/packages/a2ui_core/lib/src/core/messages.dart
@@ -11,7 +11,20 @@ abstract class A2uiMessage {
 
   /// Deserializes a JSON envelope into a typed [A2uiMessage].
   factory A2uiMessage.fromJson(Map<String, dynamic> json) {
-    final String version = json['version'] as String? ?? 'v0.9';
+    final Object? rawVersion = json['version'];
+    if (rawVersion is! String) {
+      throw A2uiValidationError(
+        "A2UI message must have a string 'version' field.",
+        details: json,
+      );
+    }
+    if (rawVersion != 'v0.9') {
+      throw A2uiValidationError(
+        "A2UI message must have version 'v0.9' (got '$rawVersion').",
+        details: json,
+      );
+    }
+    final String version = rawVersion;
 
     if (json.containsKey('createSurface')) {
       final body = json['createSurface'] as Map<String, dynamic>;

--- a/packages/a2ui_core/test/messages_test.dart
+++ b/packages/a2ui_core/test/messages_test.dart
@@ -105,6 +105,25 @@ void main() {
       );
     });
 
+    test('throws when version field is missing', () {
+      expect(
+        () => A2uiMessage.fromJson({
+          'createSurface': {'surfaceId': 's1', 'catalogId': 'c1'},
+        }),
+        throwsA(isA<A2uiValidationError>()),
+      );
+    });
+
+    test('throws when version is not v0.9', () {
+      expect(
+        () => A2uiMessage.fromJson({
+          'version': 'v0.8',
+          'createSurface': {'surfaceId': 's1', 'catalogId': 'c1'},
+        }),
+        throwsA(isA<A2uiValidationError>()),
+      );
+    });
+
     test('roundtrips through toJson/fromJson', () {
       final original = CreateSurfaceMessage(
         surfaceId: 's1',

--- a/packages/a2ui_core/test/messages_test.dart
+++ b/packages/a2ui_core/test/messages_test.dart
@@ -134,10 +134,7 @@ void main() {
       );
     });
 
-    test('throws when envelope contains more than one message-body key', () {
-      // The v0.9 schema is oneOf the four message-body keys; an envelope
-      // that carries more than one is invalid and must not be silently
-      // coerced to whichever branch happens to be checked first.
+    test('throws when more than one message type is present', () {
       expect(
         () => A2uiMessage.fromJson({
           'version': 'v0.9',

--- a/packages/a2ui_core/test/messages_test.dart
+++ b/packages/a2ui_core/test/messages_test.dart
@@ -124,6 +124,16 @@ void main() {
       );
     });
 
+    test('throws when version is not a string', () {
+      expect(
+        () => A2uiMessage.fromJson({
+          'version': 123,
+          'createSurface': {'surfaceId': 's1', 'catalogId': 'c1'},
+        }),
+        throwsA(isA<A2uiValidationError>()),
+      );
+    });
+
     test('roundtrips through toJson/fromJson', () {
       final original = CreateSurfaceMessage(
         surfaceId: 's1',


### PR DESCRIPTION
Fixes #939.