### PR TITLE
fix(genui): explicitly enforce primitive types in JSON schema validator

### DIFF
--- a/packages/genui/CHANGELOG.md
+++ b/packages/genui/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 0.9.2
 
 - **Feature**: Updated example/README.md.
+- **Fix**: `SurfaceDefinition.validate` now strictly enforces primitive data types, correctly identifying and rejecting malformed components (like numbers passed for strings) before they can cause fatal rendering crashes.
 
 ## 0.9.0
 

--- a/packages/genui/lib/src/model/ui_models.dart
+++ b/packages/genui/lib/src/model/ui_models.dart
@@ -250,12 +250,14 @@ class SurfaceDefinition {
         (t) => switch (t) {
           'string' => instance is String,
           'number' => instance is num,
-          'integer' => instance is int,
+          // A whole-valued double such as 42.0 is a valid integer.
+          'integer' =>
+            instance is num && (instance is int || instance.remainder(1) == 0),
           'boolean' => instance is bool,
           'object' => instance is Map,
           'array' => instance is List,
-          'null' => false, // instance is guaranteed non-null here
-          _ => true, // Pass unknown constraints
+          'null' => false,
+          _ => false,
         },
       );
 

--- a/packages/genui/lib/src/model/ui_models.dart
+++ b/packages/genui/lib/src/model/ui_models.dart
@@ -241,6 +241,33 @@ class SurfaceDefinition {
       return;
     }
 
+    if (schema case {'type': Object expectedType}) {
+      final List<String> types = expectedType is List
+          ? expectedType.cast<String>()
+          : [expectedType as String];
+
+      final bool isValid = types.any(
+        (t) => switch (t) {
+          'string' => instance is String,
+          'number' => instance is num,
+          'integer' => instance is int,
+          'boolean' => instance is bool,
+          'object' => instance is Map,
+          'array' => instance is List,
+          'null' => false, // instance is guaranteed non-null here
+          _ => true, // Pass unknown constraints
+        },
+      );
+
+      if (!isValid) {
+        throw A2uiValidationException(
+          'Type mismatch. Expected $types, got ${instance.runtimeType}',
+          surfaceId: surfaceId,
+          path: path,
+        );
+      }
+    }
+
     if (schema case {'const': Object? constVal} when instance != constVal) {
       throw A2uiValidationException(
         'Value mismatch. Expected $constVal, got $instance',

--- a/packages/genui/lib/src/model/ui_models.dart
+++ b/packages/genui/lib/src/model/ui_models.dart
@@ -243,8 +243,8 @@ class SurfaceDefinition {
 
     if (schema case {'type': Object expectedType}) {
       final List<String> types = expectedType is List
-          ? expectedType.cast<String>()
-          : [expectedType as String];
+          ? expectedType.map((e) => e.toString()).toList()
+          : [expectedType.toString()];
 
       final bool isValid = types.any(
         (t) => switch (t) {

--- a/packages/genui/lib/src/model/ui_models.dart
+++ b/packages/genui/lib/src/model/ui_models.dart
@@ -237,10 +237,6 @@ class SurfaceDefinition {
     Map<String, dynamic> schema,
     String path,
   ) {
-    if (instance == null) {
-      return;
-    }
-
     if (schema case {'type': Object expectedType}) {
       final List<String> types = expectedType is List
           ? expectedType.map((e) => e.toString()).toList()
@@ -256,18 +252,23 @@ class SurfaceDefinition {
           'boolean' => instance is bool,
           'object' => instance is Map,
           'array' => instance is List,
-          'null' => false,
+          'null' => instance == null,
           _ => false,
         },
       );
 
       if (!isValid) {
+        final Object actualType = instance?.runtimeType ?? 'null';
         throw A2uiValidationException(
-          'Type mismatch. Expected $types, got ${instance.runtimeType}',
+          'Type mismatch. Expected $types, got $actualType',
           surfaceId: surfaceId,
           path: path,
         );
       }
+    }
+
+    if (instance == null) {
+      return;
     }
 
     if (schema case {'const': Object? constVal} when instance != constVal) {

--- a/packages/genui/test/model/ui_models_test.dart
+++ b/packages/genui/test/model/ui_models_test.dart
@@ -118,6 +118,144 @@ void main() {
 
       surfaceDefinition.validate(schema); // Should not throw
     });
+
+    test('validate enforces primitive types '
+        '(this will fail due to the bug)', () {
+      final component = const Component(
+        id: 'test',
+        type: 'Text',
+        // BAD DATA: text is an int, but schema expects a string
+        properties: {'text': 42},
+      );
+      final surfaceDefinition = SurfaceDefinition(
+        surfaceId: 's1',
+        components: {'test': component},
+      );
+
+      final schema = S.object(
+        properties: {
+          'components': S.list(
+            items: S.object(
+              properties: {
+                'component': S.string(constValue: 'Text'),
+                'text': S.string(), // Validator should enforce this type!
+              },
+            ),
+          ),
+        },
+      );
+
+      // The schema validator should throw an exception because 'text'
+      // is an int.
+      // Since it silently ignores the 'type' keyword, this expect will FAIL,
+      // proving the bug exists.
+      expect(
+        () => surfaceDefinition.validate(schema),
+        throwsA(isA<A2uiValidationException>()),
+      );
+    });
+
+    test('validate enforces primitive types: boolean', () {
+      final component = const Component(
+        id: 'test',
+        type: 'Checkbox',
+        properties: {'checked': 'true'}, // BAD: string instead of bool
+      );
+      final surfaceDefinition = SurfaceDefinition(
+        surfaceId: 's1',
+        components: {'test': component},
+      );
+
+      final schema = S.object(
+        properties: {
+          'components': S.list(
+            items: S.object(
+              properties: {
+                'component': S.string(constValue: 'Checkbox'),
+                'checked': S.boolean(),
+              },
+            ),
+          ),
+        },
+      );
+
+      expect(
+        () => surfaceDefinition.validate(schema),
+        throwsA(isA<A2uiValidationException>()),
+      );
+    });
+
+    test('validate enforces primitive types: '
+        'number vs integer', () {
+      final componentInt = const Component(
+        id: 'test1',
+        type: 'Slider',
+        properties: {'value': 42}, // Valid integer
+      );
+      final componentDouble = const Component(
+        id: 'test2',
+        type: 'Slider',
+        properties: {'value': 42.5}, // Valid number, invalid integer
+      );
+
+      final schema = S.object(
+        properties: {
+          'components': S.list(
+            items: S.object(
+              properties: {
+                'component': S.string(constValue: 'Slider'),
+                'value': S.integer(), // Explicitly requires integer
+              },
+            ),
+          ),
+        },
+      );
+
+      // Integer should pass
+      SurfaceDefinition(
+        surfaceId: 's1',
+        components: {'test1': componentInt},
+      ).validate(schema);
+
+      // Double should fail because schema requires integer
+      expect(
+        () => SurfaceDefinition(
+          surfaceId: 's2',
+          components: {'test2': componentDouble},
+        ).validate(schema),
+        throwsA(isA<A2uiValidationException>()),
+      );
+    });
+
+    test('validate enforces primitive types: array and object', () {
+      final component = const Component(
+        id: 'test',
+        type: 'List',
+        properties: {'items': 42}, // BAD: int instead of array
+      );
+      final surfaceDefinition = SurfaceDefinition(
+        surfaceId: 's1',
+        components: {'test': component},
+      );
+
+      final schema = S.object(
+        properties: {
+          'components': S.list(
+            items: S.object(
+              properties: {
+                'component': S.string(constValue: 'List'),
+                'items': S.list(items: S.string()),
+              },
+            ),
+          ),
+        },
+      );
+
+      expect(
+        () => surfaceDefinition.validate(schema),
+        throwsA(isA<A2uiValidationException>()),
+      );
+    });
   });
 
   group('SurfaceDefinition extended', () {

--- a/packages/genui/test/model/ui_models_test.dart
+++ b/packages/genui/test/model/ui_models_test.dart
@@ -265,6 +265,36 @@ void main() {
       }
     });
 
+    test('validate rejects explicit null for a non-nullable type', () {
+      final component = const Component(
+        id: 'test',
+        type: 'Text',
+        properties: {'text': null}, // null where a string is required.
+      );
+      final surfaceDefinition = SurfaceDefinition(
+        surfaceId: 's1',
+        components: {'test': component},
+      );
+
+      final schema = S.object(
+        properties: {
+          'components': S.list(
+            items: S.object(
+              properties: {
+                'component': S.string(constValue: 'Text'),
+                'text': S.string(),
+              },
+            ),
+          ),
+        },
+      );
+
+      expect(
+        () => surfaceDefinition.validate(schema),
+        throwsA(isA<A2uiValidationException>()),
+      );
+    });
+
     test('validate enforces primitive types: array and object', () {
       final component = const Component(
         id: 'test',

--- a/packages/genui/test/model/ui_models_test.dart
+++ b/packages/genui/test/model/ui_models_test.dart
@@ -118,7 +118,7 @@ void main() {
       surfaceDefinition.validate(schema); // Should not throw.
     });
 
-    test('validate enforces primitive types ', () {
+    test('validate enforces primitive types: string', () {
       final component = const Component(
         id: 'test',
         type: 'Text',
@@ -145,7 +145,13 @@ void main() {
 
       expect(
         () => surfaceDefinition.validate(schema),
-        throwsA(isA<A2uiValidationException>()),
+        throwsA(
+          isA<A2uiValidationException>().having(
+            (e) => e.message,
+            'message',
+            contains('Type mismatch'),
+          ),
+        ),
       );
     });
 
@@ -191,6 +197,13 @@ void main() {
         type: 'Slider',
         properties: {'value': 42.5}, // Valid number, invalid integer.
       );
+      // JSON decodes whole numbers like 42.0 to a Dart double; per JSON
+      // Schema a double with a zero fractional part is still an integer.
+      final componentWholeDouble = const Component(
+        id: 'test3',
+        type: 'Slider',
+        properties: {'value': 42.0},
+      );
 
       final schema = S.object(
         properties: {
@@ -210,6 +223,11 @@ void main() {
         components: {'test1': componentInt},
       ).validate(schema);
 
+      SurfaceDefinition(
+        surfaceId: 's3',
+        components: {'test3': componentWholeDouble},
+      ).validate(schema);
+
       expect(
         () => SurfaceDefinition(
           surfaceId: 's2',
@@ -217,6 +235,34 @@ void main() {
         ).validate(schema),
         throwsA(isA<A2uiValidationException>()),
       );
+    });
+
+    test('validate accepts both int and double for number type', () {
+      final schema = S.object(
+        properties: {
+          'components': S.list(
+            items: S.object(
+              properties: {
+                'component': S.string(constValue: 'Slider'),
+                'value': S.number(),
+              },
+            ),
+          ),
+        },
+      );
+
+      for (final value in const <Object>[42, 42.5]) {
+        SurfaceDefinition(
+          surfaceId: 's1',
+          components: {
+            'test': Component(
+              id: 'test',
+              type: 'Slider',
+              properties: {'value': value},
+            ),
+          },
+        ).validate(schema);
+      }
     });
 
     test('validate enforces primitive types: array and object', () {

--- a/packages/genui/test/model/ui_models_test.dart
+++ b/packages/genui/test/model/ui_models_test.dart
@@ -75,7 +75,6 @@ void main() {
         components: {'test': component},
       );
 
-      // Schema invalidating the component (e.g., expecting type "Button")
       final schema = S.object(
         properties: {
           'components': S.list(
@@ -116,15 +115,14 @@ void main() {
         },
       );
 
-      surfaceDefinition.validate(schema); // Should not throw
+      surfaceDefinition.validate(schema); // Should not throw.
     });
 
-    test('validate enforces primitive types '
-        '(this will fail due to the bug)', () {
+    test('validate enforces primitive types ', () {
       final component = const Component(
         id: 'test',
         type: 'Text',
-        // BAD DATA: text is an int, but schema expects a string
+        // int instead of string.
         properties: {'text': 42},
       );
       final surfaceDefinition = SurfaceDefinition(
@@ -138,17 +136,13 @@ void main() {
             items: S.object(
               properties: {
                 'component': S.string(constValue: 'Text'),
-                'text': S.string(), // Validator should enforce this type!
+                'text': S.string(),
               },
             ),
           ),
         },
       );
 
-      // The schema validator should throw an exception because 'text'
-      // is an int.
-      // Since it silently ignores the 'type' keyword, this expect will FAIL,
-      // proving the bug exists.
       expect(
         () => surfaceDefinition.validate(schema),
         throwsA(isA<A2uiValidationException>()),
@@ -159,7 +153,7 @@ void main() {
       final component = const Component(
         id: 'test',
         type: 'Checkbox',
-        properties: {'checked': 'true'}, // BAD: string instead of bool
+        properties: {'checked': 'true'}, // string instead of bool.
       );
       final surfaceDefinition = SurfaceDefinition(
         surfaceId: 's1',
@@ -190,12 +184,12 @@ void main() {
       final componentInt = const Component(
         id: 'test1',
         type: 'Slider',
-        properties: {'value': 42}, // Valid integer
+        properties: {'value': 42}, // Valid integer.
       );
       final componentDouble = const Component(
         id: 'test2',
         type: 'Slider',
-        properties: {'value': 42.5}, // Valid number, invalid integer
+        properties: {'value': 42.5}, // Valid number, invalid integer.
       );
 
       final schema = S.object(
@@ -204,20 +198,18 @@ void main() {
             items: S.object(
               properties: {
                 'component': S.string(constValue: 'Slider'),
-                'value': S.integer(), // Explicitly requires integer
+                'value': S.integer(),
               },
             ),
           ),
         },
       );
 
-      // Integer should pass
       SurfaceDefinition(
         surfaceId: 's1',
         components: {'test1': componentInt},
       ).validate(schema);
 
-      // Double should fail because schema requires integer
       expect(
         () => SurfaceDefinition(
           surfaceId: 's2',
@@ -231,7 +223,7 @@ void main() {
       final component = const Component(
         id: 'test',
         type: 'List',
-        properties: {'items': 42}, // BAD: int instead of array
+        properties: {'items': 42}, // int instead of array.
       );
       final surfaceDefinition = SurfaceDefinition(
         surfaceId: 's1',


### PR DESCRIPTION
Fixes https://github.com/flutter/genui/issues/954.

Adds primitive type enforcement to surface definition validation. Mismatches result in a `A2uiValidationException`, which `SurfaceController` will round-trip to the server so it can try to correct it.

The added type semantics match what we do in `json_schema_builder`.

<!-- Links -->

[Flutter Style Guide]: https://github.com/flutter/flutter/blob/master/docs/contributing/Style-guide-for-Flutter-repo.md
[CLA]: https://cla.developers.google.com/
[Discord]: https://github.com/flutter/flutter/blob/master/docs/contributing/Chat.md
[Contributors Guide]: https://github.com/flutter/samples/blob/main/CONTRIBUTING.md
[changelog]: ../CHANGELOG.md
[e2e]: ../examples/e2e/README.md
