### PR TITLE
docs: replace CoreCatalogItems with BasicCatalogItems in READMEs

### DIFF
--- a/packages/genui/README.md
+++ b/packages/genui/README.md
@@ -127,7 +127,7 @@ provider.
        super.initState();
 
        // Create a SurfaceController with a widget catalog.
-       _controller = SurfaceController(catalogs: [CoreCatalogItems.asCatalog()]);
+       _controller = SurfaceController(catalogs: [BasicCatalogItems.asCatalog()]);
 
        // Create transport adapter
        _transport = A2uiTransportAdapter(onSend: _onSendToLLM);
@@ -269,7 +269,7 @@ To receive and display generated UI:
 
 ### 5. [Optional] Add your own widgets to the catalog
 
-In addition to using the catalog of widgets in `CoreCatalogItems`, you can
+In addition to using the catalog of widgets in `BasicCatalogItems`, you can
 create custom widgets for the agent to generate. Use the following
 instructions.
 
@@ -358,7 +358,7 @@ Include your catalog items when instantiating `SurfaceController`.
 
 ```dart
 _controller = SurfaceController(
-  catalogs: [CoreCatalogItems.asCatalog().copyWith([riddleCard])],
+  catalogs: [BasicCatalogItems.asCatalog().copyWith([riddleCard])],
 );
 ```
 

--- a/packages/genui_a2a/README.md
+++ b/packages/genui_a2a/README.md
@@ -95,7 +95,7 @@ class _ChatScreenState extends State<ChatScreen> {
   void initState() {
     super.initState();
     // Initialize the controller with the catalog
-    _controller = SurfaceController(catalogs: [CoreCatalogItems.asCatalog()]);
+    _controller = SurfaceController(catalogs: [BasicCatalogItems.asCatalog()]);
 
     // Create the transport adapter
     _transport = A2uiTransportAdapter(


### PR DESCRIPTION
# Description


This PR updates the README references to `CoreCatalogItems` with `BasicCatalogItems` now that it has been [renamed](https://github.com/flutter/genui/commit/546dab9bee0e037de9c0bb6baf2c1085682d51aa).

## Pre-launch Checklist

- [x] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [x] I signed the [CLA].
- [x] I read the [Contributors Guide].
- [ ] I have added sample code updates to the [changelog].
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] If my PR is a fork PR, I've checked that [e2e tests] passed.

If you need help, consider asking for advice on the #hackers-devrel channel on [Discord].

<!-- Links -->

[Flutter Style Guide]: https://github.com/flutter/flutter/blob/master/docs/contributing/Style-guide-for-Flutter-repo.md
[CLA]: https://cla.developers.google.com/
[Discord]: https://github.com/flutter/flutter/blob/master/docs/contributing/Chat.md
[Contributors Guide]: https://github.com/flutter/samples/blob/main/CONTRIBUTING.md
[changelog]: ../CHANGELOG.md
[e2e]: ../examples/e2e/README.md
