### PR TITLE
fix: filter empty messages without altering text

### DIFF
--- a/packages/genui/lib/src/transport/a2ui_transport_adapter.dart
+++ b/packages/genui/lib/src/transport/a2ui_transport_adapter.dart
@@ -65,8 +65,8 @@ class A2uiTransportAdapter implements Transport {
   Stream<String> get incomingText => _pipeline
       .where((e) => e is TextEvent)
       .cast<TextEvent>()
-      .map((e) => e.text.trim())
-      .where((text) => text.isNotEmpty);
+      .map((e) => e.text)
+      .where((text) => text.trim().isNotEmpty);
 
   /// A stream of A2UI messages parsed from the input.
   @override


### PR DESCRIPTION
# Description

Modify `A2uiTransportAdapter` to preserve whitespaces in AI text responses while still discarding empty text parts.
Trimming all messages causes inconsistent concatenation issues. 

Fixes #906 

BEFORE:
<img width="871" height="647" alt="Screenshot From 2026-06-17 03-54-35" src="https://github.com/user-attachments/assets/ee15485e-785e-4723-a6c8-97ce9e1db6e4" />

AFTER:
<img width="848" height="761" alt="Screenshot From 2026-06-17 03-58-48" src="https://github.com/user-attachments/assets/5b2c5849-6b10-4bc1-9ebd-b05ab6a7dfc4" />


## Pre-launch Checklist

- [x] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [x] I signed the [CLA].
- [x] I read the [Contributors Guide].
- [ ] I have added sample code updates to the [changelog].
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] If my PR is a fork PR, I've checked that [e2e tests] passed.