### PR TITLE
docs(readme): replace deprecated google_generative_ai and discontinued firebase_vertexai with firebase_ai

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ based on a widget catalog from the developers' project.
 
 ## Connecting to an AI agent
 
-The `genui` framework is designed to be backend agnostic. You can use any AI SDK (such as `google_generative_ai`, `dartantic_ai`, or `firebase_vertexai`) to generate content. The framework provides adapters (like `A2uiTransportAdapter`) to ingest the AI response and render it.
+The `genui` framework is designed to be backend agnostic. You can use any AI SDK (such as `firebase_ai` or `dartantic_ai`) to generate content. The framework provides adapters (like `A2uiTransportAdapter`) to ingest the AI response and render it.
 
 For custom agent servers that implement the A2UI protocol, you can use the `genui_a2a` package.
 

--- a/packages/genui/CHANGELOG.md
+++ b/packages/genui/CHANGELOG.md
@@ -20,6 +20,7 @@
   an error.
 - The catalog-widget authoring API is unchanged; `SurfaceDefinition` and
   `Component` remain genui types.
+- **Docs** Removed `google_generative_ai` from the README.md.
 
 ## 0.9.1
 

--- a/packages/genui/README.md
+++ b/packages/genui/README.md
@@ -90,7 +90,7 @@ running `flutter create`.
 `genui` is backend-agnostic and can connect to any agent provider. You simply need to implement the `onSend` callback in `A2uiTransportAdapter` to bridge your AI service to the framework.
 
 1.  **Implement `onSend`**: This callback takes a `ChatMessage` and returns a `Future<void>`.
-2.  **Call your AI Service**: Use your preferred AI client (e.g., `google_generative_ai`, `firebase_vertexai`, or a custom HTTP client) to send the message.
+2.  **Call your AI Service**: Use your preferred AI client (e.g., `firebase_ai` or a custom HTTP client) to send the message.
 3.  **Pipe Results**: As chunks of text arrive from the AI stream, feed them into `A2uiTransportAdapter.addChunk()`.
 
 ### 3. Create the connection to an agent


### PR DESCRIPTION
Fixes https://github.com/a2ui-project/a2ui/issues/1889 by replacing references to the deprecated `google_generative_ai` and discontinued `firebase_vertexai` with `firebase_ai`.