### PR TITLE
fix(ci): harden some workflows in genui

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -10,6 +10,9 @@ on:
   schedule:
     - cron: "0 * * * *" # hourly
 
+permissions:
+  contents: read
+
 jobs:
   eval-job:
     # Do not run on forked branches,
@@ -19,16 +22,16 @@ jobs:
     environment: eval
     steps:
       - name: Check that REPO_GEMINI_API_KEY is set and available
-        env:
-          # REPO_GEMINI_API_KEY is expected to be set in the repository secrets
-          # See https://docs.github.com/en/actions/security-guides/encrypted-secrets
-          GEMINI_API_KEY: ${{ secrets.REPO_GEMINI_API_KEY }}
         run: |
           if [ -z "$GEMINI_API_KEY" ]; then
             echo "ERROR: REPO_GEMINI_API_KEY is not set"
             exit 1
           fi
           echo "GEMINI_API_KEY has ${#GEMINI_API_KEY} characters"
+        env:
+          # REPO_GEMINI_API_KEY is expected to be set in the repository secrets
+          # See https://docs.github.com/en/actions/security-guides/encrypted-secrets
+          GEMINI_API_KEY: ${{ secrets.REPO_GEMINI_API_KEY }}
       - name: Install Flutter
         # Before bumping, verify the new version is on the flutter org's
         # enterprise actions allowlist, or CI will fail with startup_failure.
@@ -40,14 +43,16 @@ jobs:
         run: flutter --version
       - name: Checkout code
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
+        with:
+          persist-credentials: false
       - name: Install dependencies
         working-directory: tool/e2e
         run: dart pub get
       - name: Run e2e tests
         working-directory: tool/e2e
+        run: flutter test --dart-define=GEMINI_API_KEY=$GEMINI_API_KEY
         env:
           GEMINI_API_KEY: ${{ secrets.REPO_GEMINI_API_KEY }}
-        run: flutter test --dart-define=GEMINI_API_KEY=$GEMINI_API_KEY
       - name: Cache dependencies
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae
         with:

--- a/.github/workflows/flutter_packages.yaml
+++ b/.github/workflows/flutter_packages.yaml
@@ -33,6 +33,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   matrix:
     runs-on: ubuntu-latest
@@ -43,29 +46,28 @@ jobs:
         with:
           # Fetch the full history to be able to diff against the base branch
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Generate testing matrix
         id: generate_matrix
-        env:
-          GH_TOKEN: ${{ github.token }}
         run: |
           # Find all directories containing pubspec.yaml in packages, tools, and examples.
           # tool/e2e is excluded, because it requires GEMINI_API_KEY and is exercised in other workflow
           ALL_DIRS=$(find packages examples tool -name pubspec.yaml -not -path "*/.dart_tool/*" -not -path "tool/e2e/*" -exec dirname {} \;)
 
           # Get the list of changed files. The method depends on the event type.
-          if [[ "${{ github.event_name }}" == "pull_request" ]]; then
+          if [[ "$EVENT_NAME" == "pull_request" ]]; then
             # Try using gh pr diff first to get the precise list of changed files.
             # This avoids false positives if main has moved forward.
             # We wrap it in an if statement to catch failures (e.g. diff too large).
-            if ! CHANGED_FILES=$(gh pr diff --name-only ${{ github.event.pull_request.number }}); then
+            if ! CHANGED_FILES=$(gh pr diff --name-only "$PR_NUMBER"); then
               echo "Warning: 'gh pr diff' failed. This usually happens when the PR is very large."
-              echo "Falling back to 'git diff' against origin/${{ github.base_ref }}."
-              CHANGED_FILES=$(git diff --name-only origin/${{ github.base_ref }} HEAD)
+              echo "Falling back to 'git diff' against origin/${GITHUB_BASE_REF}."
+              CHANGED_FILES=$(git diff --name-only "origin/$GITHUB_BASE_REF" HEAD)
             fi
           else
             # For pushes, diff between the two SHAs of the push.
-            CHANGED_FILES=$(git diff --name-only ${{ github.event.before }} ${{ github.event.after }})
+            CHANGED_FILES=$(git diff --name-only "$EVENT_BEFORE" "$EVENT_AFTER")
           fi
 
           # Build a regex to match any of the package directories or the workflow file.
@@ -98,12 +100,20 @@ jobs:
           JSON_MATRIX="$JSON_MATRIX]"
 
           echo "matrix=$JSON_MATRIX" >> $GITHUB_OUTPUT
+        env:
+          GH_TOKEN: ${{ github.token }}
+          EVENT_NAME: ${{ github.event_name }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          EVENT_BEFORE: ${{ github.event.before }}
+          EVENT_AFTER: ${{ github.event.after }}
 
   copyright:
     runs-on: ubuntu-latest
     if: github.repository == 'flutter/genui'
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
+        with:
+          persist-credentials: false
       # Before bumping, verify the new version is on the flutter org's
       # enterprise actions allowlist, or CI will fail with startup_failure.
       - uses: subosito/flutter-action@1a449444c387b1966244ae4d4f8c696479add0b2
@@ -122,6 +132,7 @@ jobs:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
         with:
           submodules: recursive
+          persist-credentials: false
       - uses: subosito/flutter-action@1a449444c387b1966244ae4d4f8c696479add0b2
         with:
           channel: stable
@@ -145,6 +156,8 @@ jobs:
         os: [ubuntu-latest]
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
+        with:
+          persist-credentials: false
       - uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654
         with:
           distribution: "zulu"

--- a/.github/workflows/pub_health.yaml
+++ b/.github/workflows/pub_health.yaml
@@ -14,7 +14,8 @@ on:
     types: [opened, synchronize, reopened, labeled, unlabeled]
 jobs:
   health:
-    uses: dart-lang/ecosystem/.github/workflows/health.yaml@main
+    # Ignored because dart-lang ecosystem reusable workflows are designed to run from @main.
+    uses: dart-lang/ecosystem/.github/workflows/health.yaml@main # zizmor: ignore[unpinned-uses]
     with:
       checks: "changelog"
     permissions:

--- a/.github/workflows/pub_post_summaries.yaml
+++ b/.github/workflows/pub_post_summaries.yaml
@@ -7,7 +7,8 @@
 name: Comment on the pull request
 
 on:
-  workflow_run:
+  # Ignored because workflow_run is used securely to post comments without giving PR workflows write permissions.
+  workflow_run: # zizmor: ignore[dangerous-triggers]
     workflows: 
       - Publish
     types:
@@ -15,6 +16,7 @@ on:
 
 jobs:
   upload:
-    uses: dart-lang/ecosystem/.github/workflows/post_summaries.yaml@main
+    # Ignored because dart-lang ecosystem reusable workflows are designed to run from @main.
+    uses: dart-lang/ecosystem/.github/workflows/post_summaries.yaml@main # zizmor: ignore[unpinned-uses]
     permissions:
       pull-requests: write

--- a/.github/workflows/pub_publish.yaml
+++ b/.github/workflows/pub_publish.yaml
@@ -17,7 +17,8 @@ on:
 jobs:
   publish:
     if: ${{ github.repository_owner == 'flutter' }}
-    uses: dart-lang/ecosystem/.github/workflows/publish.yaml@main
+    # Ignored because dart-lang ecosystem reusable workflows are designed to run from @main.
+    uses: dart-lang/ecosystem/.github/workflows/publish.yaml@main # zizmor: ignore[unpinned-uses]
     with:
       # See https://github.com/dart-lang/ecosystem/tree/main/pkgs/firehose#options
       sdk: beta # version of dart sdk to use for publishing

--- a/.github/workflows/triage.yaml
+++ b/.github/workflows/triage.yaml
@@ -22,7 +22,8 @@ on:
   schedule:
     - cron: "0 15 * * *" # daily at 15:00 UTC
   # React promptly to the events that can change a PR's flag state.
-  pull_request_target:
+  # Ignored since pull_request_target is used safely here (checks out main branch to run triage script).
+  pull_request_target: # zizmor: ignore[dangerous-triggers]
     types: [opened, edited, reopened, ready_for_review, synchronize]
   issue_comment:
     types: [created]


### PR DESCRIPTION
fixes: flutter/flutter#189099

```
❯ zizmor --gh-token=$(gh auth token) .github/workflows
 INFO zizmor: 🌈 zizmor v1.25.2
 INFO audit: zizmor: 🌈 completed .github/workflows/e2e.yaml
 INFO audit: zizmor: 🌈 completed .github/workflows/flutter_packages.yaml
 INFO audit: zizmor: 🌈 completed .github/workflows/pub_health.yaml
 INFO audit: zizmor: 🌈 completed .github/workflows/pub_post_summaries.yaml
 INFO audit: zizmor: 🌈 completed .github/workflows/pub_publish.yaml
 INFO audit: zizmor: 🌈 completed .github/workflows/triage-sla.yaml
 INFO audit: zizmor: 🌈 completed .github/workflows/triage.yaml
No findings to report. Good job! (5 ignored, 34 suppressed)
```