### PR TITLE
Rename file from 'publishing' to 'release'.

### DIFF
--- a/docs/contributing/release.md
+++ b/docs/contributing/release.md
@@ -1,5 +1,5 @@
 
-# Publishing 
+# Release process 
 
 Publishing to [pub.dev](https://pub.dev) happens automatically via GitHub Actions, with the help of
 [firehose rules](https://github.com/dart-lang/ecosystem/tree/main/pkgs/firehose).


### PR DESCRIPTION
This is needed for consistency with other related docs on a2ui.