### PR TITLE
chore: release a2ui_core 0.1.0; bump genui and genui_a2a to 0.10.1

### DIFF
--- a/dev_tools/catalog_gallery/pubspec.yaml
+++ b/dev_tools/catalog_gallery/pubspec.yaml
@@ -13,7 +13,7 @@ environment:
 resolution: workspace
 
 dependencies:
-  a2ui_core: ^0.0.1-wip002
+  a2ui_core: ^0.1.0
   args: ^2.7.0
   file: ^7.0.1
   flutter:

--- a/dev_tools/composer/pubspec.yaml
+++ b/dev_tools/composer/pubspec.yaml
@@ -12,7 +12,7 @@ environment:
 resolution: workspace
 
 dependencies:
-  a2ui_core: ^0.0.1-wip002
+  a2ui_core: ^0.1.0
   dartantic_ai: ^3.2.0
   flutter:
     sdk: flutter

--- a/examples/simple_chat/pubspec.yaml
+++ b/examples/simple_chat/pubspec.yaml
@@ -12,7 +12,7 @@ environment:
 resolution: workspace
 
 dependencies:
-  a2ui_core: ^0.0.1-wip002
+  a2ui_core: ^0.1.0
   dartantic_ai: ^3.2.0
   flutter:
     sdk: flutter

--- a/examples/verdure/client/pubspec.yaml
+++ b/examples/verdure/client/pubspec.yaml
@@ -14,7 +14,7 @@ environment:
 resolution: workspace
 
 dependencies:
-  a2ui_core: ^0.0.1-wip002
+  a2ui_core: ^0.1.0
   device_info_plus: ^13.1.0
   flutter:
     sdk: flutter

--- a/packages/a2ui_core/CHANGELOG.md
+++ b/packages/a2ui_core/CHANGELOG.md
@@ -1,5 +1,9 @@
 # `a2ui_core` Changelog
 
+## 0.1.0
+
+- First non-pre-release version. No functional changes since 0.0.1-wip002.
+
 ## 0.0.1-wip002
 
 - **Feature**: Export `effect`.

--- a/packages/a2ui_core/pubspec.yaml
+++ b/packages/a2ui_core/pubspec.yaml
@@ -5,7 +5,7 @@
 name: a2ui_core
 description: Core package for A2UI protocol.
 repository: https://github.com/flutter/genui/tree/main/packages/a2ui_core
-version: 0.0.1-wip002
+version: 0.1.0
 
 resolution: workspace
 

--- a/packages/genui/CHANGELOG.md
+++ b/packages/genui/CHANGELOG.md
@@ -1,5 +1,9 @@
 # `genui` Changelog
 
+## 0.10.1
+
+- Depend on `a2ui_core` 0.1.0, its first non-pre-release version.
+
 ## 0.10.0
 
 - **BREAKING**: Changed `SurfaceDefinition.validate` to be asynchronous to support resolving `$ref` schemas via `SchemaRegistry`.

--- a/packages/genui/pubspec.yaml
+++ b/packages/genui/pubspec.yaml
@@ -4,7 +4,7 @@
 
 name: genui
 description: Generates and displays generative user interfaces (GenUI) in Flutter using AI.
-version: 0.10.0
+version: 0.10.1
 homepage: https://github.com/flutter/genui/tree/main/packages/genui
 license: BSD-3-Clause
 issue_tracker: https://github.com/flutter/genui/issues
@@ -16,7 +16,7 @@ environment:
 resolution: workspace
 
 dependencies:
-  a2ui_core: ^0.0.1-dev002
+  a2ui_core: ^0.1.0
   audioplayers: ^6.6.0
   collection: ^1.19.1
   flutter:

--- a/packages/genui_a2a/CHANGELOG.md
+++ b/packages/genui_a2a/CHANGELOG.md
@@ -1,5 +1,9 @@
 # `genui_a2a` Changelog
 
+## 0.10.1
+
+- Depend on `a2ui_core` 0.1.0, its first non-pre-release version.
+
 ## 0.10.0
 
 - **BREAKING**: `A2uiAgentConnector.stream` now emits `package:a2ui_core`

--- a/packages/genui_a2a/pubspec.yaml
+++ b/packages/genui_a2a/pubspec.yaml
@@ -4,7 +4,7 @@
 
 name: genui_a2a
 description: Integration package for genui and A2UI Streaming UI Protocol.
-version: 0.10.0
+version: 0.10.1
 homepage: https://github.com/flutter/genui/tree/main/packages/genui_a2a
 license: BSD-3-Clause
 issue_tracker: https://github.com/flutter/genui/issues
@@ -16,7 +16,7 @@ environment:
 resolution: workspace
 
 dependencies:
-  a2ui_core: ^0.0.1-wip002
+  a2ui_core: ^0.1.0
   collection: ^1.19.1
   flutter:
     sdk: flutter

--- a/packages/genui_a2a/pubspec.yaml
+++ b/packages/genui_a2a/pubspec.yaml
@@ -11,7 +11,7 @@ issue_tracker: https://github.com/flutter/genui/issues
 
 environment:
   sdk: ">=3.10.0 <4.0.0"
-  flutter: ">=3.35.7 <4.0.0"
+  flutter: ">=3.35.7"
 
 resolution: workspace
 


### PR DESCRIPTION
Publishes a2ui_core as a non-pre-release version and moves its dependents onto it.

**Context:** `genui 0.10.0` exposes `a2ui_core` types in its public API, but its `^0.0.1-dev002` constraint resolves to the pre-release `0.0.1-wip002`, so every `genui` consumer transitively depends on a pre-release package. 

This bumps `a2ui_core to 0.1.0` (identical in content to `0.0.1-wip002`) and updates all in-repo constraints to `^0.1.0`.

Starting at `0.1.0` rather than `0.0.1` lets additive changes (or bug patches) ship as 0.1.x without constraint bumps in dependents.

Fixes a2ui-project/a2ui#2043

Fixes a2ui-project/a2ui#2010