### PR TITLE
Fix/email validation regex

### DIFF
--- a/packages/genui/lib/src/catalog/basic_functions.dart
+++ b/packages/genui/lib/src/catalog/basic_functions.dart
@@ -309,7 +309,7 @@ class EmailFunction extends SynchronousClientFunction {
   Object? executeSync(JsonMap args, ExecutionContext _) {
     final Object? value = args['value'];
     if (value is! String) return false;
-    final emailRegex = RegExp(r'^[^@]+@[^@]+\.[^@]+\$');
+    final emailRegex = RegExp(r'^[^@]+@[^@]+\.[^@]+$');
     return emailRegex.hasMatch(value);
   }
 }

--- a/packages/genui/test/catalog/basic_functions_test.dart
+++ b/packages/genui/test/catalog/basic_functions_test.dart
@@ -72,6 +72,29 @@ void main() {
       expect(await run<int>(func, {'value': null}), 0);
     });
 
+    test('email', () async {
+      final EmailFunction func = BasicFunctions.emailFunction;
+
+      // Valid emails (Gmail)
+      expect(await run<bool>(func, {'value': 'zhangsan@gmail.com'}), isTrue);
+      expect(await run<bool>(func, {'value': 'a@gmail.c'}), isTrue);
+      expect(await run<bool>(func, {'value': 'first.last@gmail.com'}), isTrue);
+      expect(await run<bool>(func, {'value': 'user+tag@gmail.com'}), isTrue);
+
+      // Invalid emails
+      expect(await run<bool>(func, {'value': ''}), isFalse);
+      expect(await run<bool>(func, {'value': 'plainaddress'}), isFalse);
+      expect(await run<bool>(func, {'value': '@gmail.com'}), isFalse);
+      expect(await run<bool>(func, {'value': 'no-domain@'}), isFalse);
+      expect(await run<bool>(func, {'value': 'no-tld@gmail'}), isFalse);
+      expect(await run<bool>(func, {'value': 'a@gmail@gmail.com'}), isFalse);
+
+      // Non-string values return false
+      expect(await run<bool>(func, {'value': null}), isFalse);
+      expect(await run<bool>(func, {'value': 123}), isFalse);
+      expect(await run<bool>(func, <String, Object?>{}), isFalse);
+    });
+
     test('and', () async {
       final AndFunction func = BasicFunctions.andFunction;
       expect(


### PR DESCRIPTION
Fix the email validation function by correcting the regex escape pattern.

The previous implementation used an escaped `$` in a raw string, which caused the regex to match a literal `$` character instead of the end-of-string anchor.

Update the regex pattern to properly validate email formats.

# Description

This PR fixes an issue in the email validation function where the regular expression pattern did not correctly handle the end-of-string anchor.

The previous implementation incorrectly escaped the `$` character inside a Dart raw string. As a result, the regex engine treated it as a literal character instead of the end-of-string matcher, causing valid email addresses to fail validation.

This change updates the regex pattern to use the correct `$` anchor and ensures email validation behaves as expected.

## Related Issues

N/A

## Testing

- Verified that valid email addresses are correctly accepted.
- Verified that invalid email formats are rejected.

## Pre-launch Checklist

- [x] The code changes have been tested.
- [x] The updated validation logic works as expected.
- [ ] Documentation updates are not required.