### PR TITLE
chore: prepare genui 0.10.3 release

### DIFF
--- a/packages/genui/CHANGELOG.md
+++ b/packages/genui/CHANGELOG.md
@@ -1,10 +1,12 @@
 # [genui](https://pub.dev/packages/genui) Changelog
 
-## 0.10.2
+## 0.10.3
 
 - Fixed `PluralizeFunction` to use `Intl.pluralLogic` instead of `Intl.plural` to
   avoid message extraction errors when arguments are dynamic runtime
   expressions.
+
+## 0.10.2
 
 - Fixed `A2uiTransportAdapter.incomingText` trimming every streamed chunk, which
   made words run together when chunks were concatenated.

--- a/packages/genui/pubspec.yaml
+++ b/packages/genui/pubspec.yaml
@@ -4,7 +4,7 @@
 
 name: genui
 description: Generates and displays generative user interfaces (GenUI) in Flutter using AI.
-version: 0.10.2
+version: 0.10.3
 homepage: https://github.com/flutter/genui/tree/main/packages/genui
 license: BSD-3-Clause
 issue_tracker: https://github.com/flutter/genui/issues


### PR DESCRIPTION
# Description

Bumps `package:genui` to `0.10.3` and creates the `0.10.3` changelog section for the `PluralizeFunction` fix merged in #1027.

`0.10.2` was previously published to pub.dev on August 12 without #1027, so a patch bump is needed to release the change to pub.dev.

## Pre-launch Checklist

- [x] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [x] I signed the [CLA].
- [x] I read the [Contributors Guide].
- [x] I have added sample code updates to the [changelog].
- [x] I updated/added relevant documentation (doc comments with `///`).

<!-- Links -->

[Flutter Style Guide]: https://github.com/flutter/flutter/blob/master/docs/contributing/Style-guide-for-Flutter-repo.md
[CLA]: https://cla.developers.google.com/
[Discord]: https://github.com/flutter/flutter/blob/master/docs/contributing/Chat.md
[Contributors Guide]: https://github.com/flutter/samples/blob/main/CONTRIBUTING.md
[changelog]: ../CHANGELOG.md